### PR TITLE
Fixes #78 (partly) - Websearch support

### DIFF
--- a/src/components/ChatApp.css
+++ b/src/components/ChatApp.css
@@ -196,3 +196,29 @@ textarea {
   height: 25px;
 }
 
+.websearchtile{
+  width: 100%;
+  height: 150px;
+}
+
+.websearchtile-auto{
+  width: 100%;
+  height: auto;
+}
+.websearchtile-img{
+  width: 30%;
+  height: 100%;
+  float: left;
+}
+
+.websearchtile-text{
+  padding: 1% 1% 2% 35%;
+}
+
+.websearchtile-auto-text{
+  padding: 1% 1% 2% 2%;
+}
+
+.websearchtile-category{
+  color: #999999;
+}

--- a/src/components/MessageListItem.react.js
+++ b/src/components/MessageListItem.react.js
@@ -12,6 +12,7 @@ import {
 } from 'material-ui/Table';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import { divIcon } from 'leaflet';
+import Paper from 'material-ui/Paper';
 
 export function parseAndReplace(text) {
   return <Linkify properties={{target: '_blank'}}>
@@ -19,14 +20,101 @@ export function parseAndReplace(text) {
   </Linkify>;
 }
 
-function drawMap(lat,lng){
+
+function drawWebSearchTiles(tilesData){
+  let resultTiles = tilesData.map((tile,i) => {
+    let category = 'Popular';
+    if(tile.hasOwnProperty('Name')){
+      category = tile.Name;
+      tile = tile.Topics[0];
+    }
+
+    if(tile.Icon.URL){
+      return(
+        <div key={i}>
+          <MuiThemeProvider>
+            <Paper zDepth={2} className='websearchtile'>
+              <img src={tile.Icon.URL} className='websearchtile-img' alt=''/>
+              <div className='websearchtile-text'>
+                <p className='websearchtile-category'>
+                  Category: <strong>{category}</strong>
+                </p>
+                {tile.Text}<br/>
+                <a href={tile.FirstURL} target='_blank'
+                  rel='noopener noreferrer'>Know more</a>
+              </div>
+            </Paper>
+          </MuiThemeProvider>
+          <div>
+            <br/>
+          </div>
+        </div>
+        );
+   }
+   return(
+    <div key={i}>
+      <MuiThemeProvider>
+        <Paper zDepth={2} className='websearchtile-auto'>
+          <div className='websearchtile-auto-text'>
+            <p className='websearchtile-category'>
+              Category: <strong>{category}</strong>
+            </p>
+            {tile.Text}<br/>
+            <a href={tile.FirstURL} target='_blank'
+              rel='noopener noreferrer'>Know more</a>
+          </div>
+        </Paper>
+      </MuiThemeProvider>
+      <div>
+        <br/>
+      </div>
+    </div>
+    );
+  });
+
+  return resultTiles;
+}
+
+function drawTable(coloumns,tableData){
+  let tableheader = Object.keys(coloumns).map((key,i) =>{
+    return(<TableHeaderColumn key={i}>{coloumns[key]}</TableHeaderColumn>);
+  });
+  let rows = tableData.map((eachrow,j) => {
+    let rowcols = Object.keys(coloumns).map((key,i) =>{
+      return(
+        <TableRowColumn key={i}>
+          <Linkify properties={{target:'_blank'}}>
+            {eachrow[key]}
+          </Linkify>
+        </TableRowColumn>
+      );
+    });
+    return(
+      <TableRow key={j}>{rowcols}</TableRow>
+    );
+  });
+
+  const table =
+  <MuiThemeProvider>
+    <Table selectable={false}>
+    <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
+      <TableRow>{tableheader}</TableRow>
+    </TableHeader>
+    <TableBody displayRowCheckbox={false}>{rows}</TableBody>
+    </Table>
+  </MuiThemeProvider>
+
+  return table;
+}
+
+function drawMap(lat,lng,zoom){
   let position = [lat, lng];
   const icon = divIcon({
     className: 'map-marker-icon',
     iconSize: [35, 35]
   });
   const map = (
-   <Map center={position} zoom={13}>
+   <Map center={position} zoom={zoom}>
       <TileLayer
         attribution=''
         url='http://{s}.tile.osm.org/{z}/{x}/{y}.png'
@@ -60,63 +148,30 @@ class MessageListItem extends React.Component {
     if(this.props.message.hasOwnProperty('response')){
       if(Object.keys(this.props.message.response).length > 0){
         let data = this.props.message.response;
-        let tableData = data.answers[0].data;
-        let mapType = false;
-        let lat, lng;
+        let actions = this.props.message.actions;
 
-        let SpecialResponseChoice = data.answers[0].actions[0];
-        if (SpecialResponseChoice.type === 'table') {
-            let coloumns = data.answers[0].actions[0].columns;
-            let tableheader = Object.keys(coloumns).map(key =>{
-              return <TableHeaderColumn key={key}>
-                {coloumns[key]}
-              </TableHeaderColumn>;
-            });
-
-            let rows = data.answers[0].data.map((eachrow, i) => {
-              let rowcols = Object.keys(coloumns).map(key =>{
-                return <TableRowColumn key={key}>
-                  <Linkify properties={{ target: '_blank' }}>
-                    {eachrow[key]}
-                  </Linkify>
-                </TableRowColumn>;
-              });
-              return(
-                <TableRow key={i}>{rowcols}</TableRow>
+        if (actions.indexOf('table')>=0) {
+            let actionIndex = actions.indexOf('table');
+            let coloumns = data.answers[0].actions[actionIndex].columns;
+            let table = drawTable(coloumns,data.answers[0].data);
+            return (
+                <li className='message-list-item'>
+                  <h5 className='message-author-name'>{message.authorName}</h5>
+                  <div className='message-time'>
+                    {message.date.toLocaleTimeString()}
+                  </div>
+                  <div className='message-text'>{replacedText}</div>
+                  <br/>
+                  <div><div className='message-text'>{table}</div></div>
+                </li>
               );
-            });
-
-            let table =
-            <MuiThemeProvider>
-              <Table selectable={false}>
-              <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
-                <TableRow>{tableheader}</TableRow>
-              </TableHeader>
-              <TableBody displayRowCheckbox={false}>{rows}</TableBody>
-              </Table>
-            </MuiThemeProvider>
-
-            return(
-              <li className="message-list-item">
-                <h5 className="message-author-name">{message.authorName}</h5>
-                <div className="message-time">
-                  {message.date.toLocaleTimeString()}
-                </div>
-                <div><div className="message-text">{table}</div></div>
-              </li>
-            );
         }
-
-        if (tableData[0].hasOwnProperty('lat') ||
-          tableData[0].hasOwnProperty('lon')
-        ) {
-          // Need to give out a map.
-          mapType = true;
-          lat = tableData[0].lat;
-          lng = tableData[0].lon;
-        }
-        if (mapType === true) {
-          let mymap = drawMap(lat,lng);
+        if (actions.indexOf('map')>=0) {
+          let actionIndex = actions.indexOf('map');
+          let lat = parseFloat(data.answers[0].actions[actionIndex].latitude);
+          let lng = parseFloat(data.answers[0].actions[actionIndex].longitude);
+          let zoom = parseFloat(data.answers[0].actions[actionIndex].zoom);
+          let mymap = drawMap(lat,lng,zoom);
           return (
                   <li className='message-list-item'>
                     <h5 className='message-author-name'>
@@ -130,6 +185,21 @@ class MessageListItem extends React.Component {
                     <div>{mymap}</div>
                   </li>
                 );
+        }
+        if (actions.indexOf('websearch')>=0) {
+          let results = this.props.message.websearchresults;
+          let WebSearchTiles = drawWebSearchTiles(results);
+          return (
+            <li className='message-list-item'>
+              <h5 className='message-author-name'>{message.authorName}</h5>
+              <div className='message-time'>
+                {message.date.toLocaleTimeString()}
+              </div>
+              <div className='message-text'>{replacedText}</div>
+              <br/>
+              <div><div className='message-text'>{WebSearchTiles}</div></div>
+            </li>
+          );
         }
       }
     }

--- a/src/utils/ChatMessageUtils.js
+++ b/src/utils/ChatMessageUtils.js
@@ -27,6 +27,8 @@ export function getSUSIMessageData(message, currentThreadID) {
     authorName: 'SUSI', // hard coded for the example
     text: message.text,
     response: message.response,
+    actions: message.actions,
+    websearchresults: message.websearchresults,
     date: new Date(timestamp),
     isRead: true,
     responseTime: message.responseTime
@@ -34,5 +36,4 @@ export function getSUSIMessageData(message, currentThreadID) {
 
   return receivedMessage;
 }
-
 


### PR DESCRIPTION
Demo Link: http://susiwebsearch.surge.sh/
Sample Queries: 'Germany', 'Marvel', 'artificial Intelligence' etc which give action type websearch

For few queries like 'find me restaurants', even duckduckgo doesnt give any response. How to handle such cases?

Also the css can be changed. And the number of results too.
Right now, Im displaying all results without 'Name' attribute i.e popular results and one from each category (when 'Name' attribute is present).

![ai](https://cloud.githubusercontent.com/assets/13276887/26603775/abe20c5a-45a5-11e7-8d56-a91f1a20fda3.png)

I refactored MessageListItem.js as I added actions attribute to message. I know its not related to this issue, will take care from next time :)

Also added the abstract if present as the first tile - but needs css support
