### PR TITLE
Fixes #110 - Disables zoom feature in the mobile site

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
     <!--


### PR DESCRIPTION
Fixes **Issue #110**

**Changes:**
Zooming is disabled now to ensure responsiveness of the chat on phones.

**Demo Link:**

Please test in phones.
http://susi.surge.sh


