### PR TITLE
Fixes #102 - Parse response to show images

### DIFF
--- a/src/components/MessageListItem.react.js
+++ b/src/components/MessageListItem.react.js
@@ -20,6 +20,29 @@ export function parseAndReplace(text) {
   </Linkify>;
 }
 
+function imageParse(stringWithLinks){
+  let replacePattern = new RegExp([
+                      '((?:https?:\\/\\/)(?:[a-zA-Z]{1}',
+                      '(?:[\\w-]+\\.)+(?:[\\w]{2,5}))',
+                      '(?::[\\d]{1,5})?\\/(?:[^\\s/]+\\/)',
+                      '*(?:[^\\s]+\\.(?:jpe?g|gif|png))',
+                      '(?:\\?\\w+=\\w+(?:&\\w+=\\w+)*)?)'
+                      ].join(''),'gim');
+  let splits = stringWithLinks.split(replacePattern);
+  let result = [];
+  splits.forEach((item,key)=>{
+    let checkmatch = item.match(replacePattern);
+    if(checkmatch){
+      result.push(
+        <img key={key} src={checkmatch}
+            style={{width:'95%',height:'auto'}} alt=''/>)
+    }
+    else{
+      result.push(item);
+    }
+  });
+  return result;
+}
 
 function drawWebSearchTiles(tilesData){
   let resultTiles = tilesData.map((tile,i) => {
@@ -143,7 +166,8 @@ class MessageListItem extends React.Component {
   render() {
     let {message} = this.props;
     let stringWithLinks = this.props.message.text;
-    let replacedText = parseAndReplace(stringWithLinks);
+    let imgText = imageParse(stringWithLinks);
+    let replacedText = parseAndReplace(imgText);
 
     if(this.props.message.hasOwnProperty('response')){
       if(Object.keys(this.props.message.response).length > 0){


### PR DESCRIPTION
Fixes issue #102 

**Changes:**
Matched response text with a regex to parse image URLs and replace with img tags.

**Demo Link:** http://imagesupport.surge.sh/

**Sample Query:** 
 - random gif 
 - get me a meme

**Screenshots:**
![imgsup](https://cloud.githubusercontent.com/assets/13276887/26688844/660c30b2-4711-11e7-8fa2-c75d6165101b.png)
 
