### PR TITLE
Fixes #92 - Digging out previous chat messages

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -89,7 +89,6 @@ export function createSUSIMessage(createdMessage, currentThreadID) {
                 abstractTile.Text = data.AbstractText;
                 abstractTile.FirstURL = data.AbstractURL;
                 abstractTile.Icon.URL = data.Image;
-                console.log(abstractTile);
                 receivedMessage.websearchresults.unshift(abstractTile);
               }
               let message =  ChatMessageUtils.getSUSIMessageData(
@@ -121,3 +120,99 @@ export function createSUSIMessage(createdMessage, currentThreadID) {
     }
   });
 };
+
+export function getHistory(){
+
+  $.ajax({
+    url: 'http://api.susi.ai/susi/memory.json',
+    dataType: 'jsonp',
+    crossDomain: true,
+    timeout: 3000,
+    async: false,
+    success: function (history) {
+      history.cognitions.forEach((cognition)=>{
+
+        let susiMsg =  {
+          id: 'm_',
+          threadID: 't_1',
+          authorName: 'SUSI', // hard coded for the example
+          text: '',
+          response: {},
+          actions:[],
+          websearchresults:[],
+          date: '',
+          isRead: true,
+        };
+
+        let userMsg = {
+          id: 'm_',
+          threadID: 't_1',
+          authorName: 'You',
+          date: '',
+          text: '',
+          isRead: true
+        };
+
+        let query = cognition.query;
+
+        userMsg.id = 'm_'+Date.parse(cognition.query_date);
+        userMsg.date = new Date(cognition.query_date);
+        userMsg.text = query;
+
+        susiMsg.id = 'm_'+Date.parse(cognition.answer_date);
+        susiMsg.date = new Date(cognition.answer_date);
+        susiMsg.text = cognition.answers[0].actions[0].expression;
+        susiMsg.response = cognition;
+
+        let actions = [];
+        cognition.answers[0].actions.forEach((actionObj) =>{
+          actions.push(actionObj.type);
+        });
+        susiMsg.actions = actions;
+
+        if (actions.indexOf('websearch')>=0) {
+          $.ajax({
+            url: 'http://api.duckduckgo.com/?format=json&q='+query,
+            dataType: 'jsonp',
+            crossDomain: true,
+            timeout: 3000,
+            async: false,
+            success: function (data) {
+              susiMsg.websearchresults = data.RelatedTopics;
+              if(data.AbstractText){
+                let abstractTile = {
+                  Text:'',
+                  FirstURL:'',
+                  Icon:{URL:''},
+                }
+                abstractTile.Text = data.AbstractText;
+                abstractTile.FirstURL = data.AbstractURL;
+                abstractTile.Icon.URL = data.Image;
+                susiMsg.websearchresults.unshift(abstractTile);
+              }
+            },
+            error: function(errorThrown) {
+              console.log(errorThrown);
+              susiMsg.text = 'Please check your internet connection';
+            }
+          });
+        }
+
+        let message = userMsg;
+        ChatAppDispatcher.dispatch({
+          type: ActionTypes.STORE_HISTORY_MESSAGE,
+          message
+        });
+
+        message = susiMsg;
+        ChatAppDispatcher.dispatch({
+          type: ActionTypes.STORE_HISTORY_MESSAGE,
+          message
+        });
+      });
+    },
+    error: function(errorThrown) {
+      console.log(errorThrown);
+    }
+  });
+}

--- a/src/components/MessageListItem.react.js
+++ b/src/components/MessageListItem.react.js
@@ -166,8 +166,11 @@ class MessageListItem extends React.Component {
   render() {
     let {message} = this.props;
     let stringWithLinks = this.props.message.text;
-    let imgText = imageParse(stringWithLinks);
-    let replacedText = parseAndReplace(imgText);
+    let replacedText = '';
+    if(stringWithLinks){
+      let imgText = imageParse(stringWithLinks);
+      replacedText = parseAndReplace(imgText);
+    }
 
     if(this.props.message.hasOwnProperty('response')){
       if(Object.keys(this.props.message.response).length > 0){

--- a/src/constants/ChatConstants.js
+++ b/src/constants/ChatConstants.js
@@ -8,7 +8,8 @@ export default {
     RECEIVE_RAW_CREATED_MESSAGE: null,
     CREATE_SUSI_MESSAGE: null,
     RECEIVE_SUSI_MESSAGE: null,
-    RECEIVE_RAW_MESSAGES: null
+    RECEIVE_RAW_MESSAGES: null,
+    STORE_HISTORY_MESSAGE: null
   })
 
 };

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import * as ChatWebAPIUtils from './utils/ChatWebAPIUtils';
 
+ChatWebAPIUtils.getHistory();
 ChatWebAPIUtils.getAllMessages();
 
 ReactDOM.render(

--- a/src/stores/MessageStore.js
+++ b/src/stores/MessageStore.js
@@ -103,6 +103,12 @@ MessageStore.dispatchToken = ChatAppDispatcher.register(action => {
       break;
     }
 
+    case ActionTypes.STORE_HISTORY_MESSAGE: {
+      let message = action.message;
+      _messages[message.id] = message;
+      MessageStore.emitChange();
+      break;
+    }
 
     default:
       // do nothing

--- a/src/utils/ChatWebAPIUtils.js
+++ b/src/utils/ChatWebAPIUtils.js
@@ -18,3 +18,7 @@ export function getAllMessages() {
     Actions.receiveAll(messages);
   });
 };
+
+export function getHistory(){
+	Actions.getHistory();
+}


### PR DESCRIPTION
Fixes issue #92 

**Changes:**
Added a new action and corresponding functions to get history from the memory servlet : http://api.susi.ai/susi/memory.json and display it in the chat app

**Demo Link:** [getsusihistory.surge.sh](getsusihistory.surge.sh)

Since the accounting system is not yet integrated into webchat and the memory servlet gives empty response for anonymous users, try some queries in the android or iOS app till you see some cognitions in http://api.susi.ai/susi/memory.json and then go to getsusihistory.surge.sh

OR

I hardcoded sample history without calling memory servlet for demo purpose.
visit [susihistory.surge.sh](susihistory.surge.sh) to see some history displayed.
sample history found at https://gist.github.com/uday96/41c4486c052f6348445af77f9cdb8e68#file-actions-js-L224-L1355

**Screenshot:**

![hist](https://cloud.githubusercontent.com/assets/13276887/26695755/9f8c83ce-4729-11e7-919f-9910508069cf.png)
 
