### PR TITLE
Fixes #125 - Rectifies websearch tiles css

### DIFF
--- a/src/components/ChatApp.css
+++ b/src/components/ChatApp.css
@@ -242,35 +242,54 @@ textarea {
   margin-left: auto;
   margin-right: 12px;
 }
+
 .websearchtile{
   width: 100%;
-  height: 150px;
+  height: 100px;
 }
 
-.websearchtile-auto{
-  width: 100%;
-  height: auto;
-}
 .websearchtile-img{
-  width: 30%;
-  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
   float: left;
+  text-align: center;
+  position: relative;
+  margin: 0 auto;
+  position: absolute;
+  left: 0;
+  right: 0;
 }
 
 .websearchtile-text{
-  padding: 1% 1% 2% 35%;
-}
-
-.websearchtile-auto-text{
-  padding: 1% 1% 2% 2%;
+  position: relative;
+  padding: 0 2% 2% 2%;
+  margin: 0 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .websearchtile-category{
   color: #999999;
 }
+
+.websearchtile-img-container{
+  background-color: #f2f2f2;
+  text-align: center;
+  position: relative;
+  width: 30%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  float: left;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+
 a {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: block
+  display: block;
 }

--- a/src/components/MessageListItem.react.js
+++ b/src/components/MessageListItem.react.js
@@ -56,8 +56,10 @@ function drawWebSearchTiles(tilesData){
       return(
         <div key={i}>
           <MuiThemeProvider>
-            <Paper zDepth={2} className='websearchtile'>
-              <img src={tile.Icon.URL} className='websearchtile-img' alt=''/>
+            <Paper zDepth={0} className='websearchtile'>
+              <div className='websearchtile-img-container'>
+                <img src={tile.Icon.URL} className='websearchtile-img' alt=''/>
+              </div>
               <div className='websearchtile-text'>
                 <p className='websearchtile-category'>
                   Category: <strong>{category}</strong>
@@ -72,13 +74,13 @@ function drawWebSearchTiles(tilesData){
             <br/>
           </div>
         </div>
-        );
+      );
    }
    return(
     <div key={i}>
       <MuiThemeProvider>
-        <Paper zDepth={2} className='websearchtile-auto'>
-          <div className='websearchtile-auto-text'>
+        <Paper zDepth={0} className='websearchtile'>
+          <div className='websearchtile-text'>
             <p className='websearchtile-category'>
               Category: <strong>{category}</strong>
             </p>
@@ -93,6 +95,7 @@ function drawWebSearchTiles(tilesData){
       </div>
     </div>
     );
+
   });
 
   return resultTiles;
@@ -218,6 +221,7 @@ class MessageListItem extends React.Component {
             <li className='message-list-item'>
               <section className={messageContainerClasses}>
               <div className='message-text'>{replacedText}</div>
+              <br/>
               <div><div className='message-text'>{WebSearchTiles}</div></div>
               <div className='message-time'>
                 {message.date.toLocaleTimeString()}


### PR DESCRIPTION
Fixes issue #125 

**Changes:**
Added overflow checks to maintain the websearch tiles size and a image container to display images without stretching.

**Demo Link:**  http://websearchcss.surge.sh/ 

**Sample Query:** search for *

**Screenshot:** 

![screenshot from 2017-06-03 03 16 29](https://cloud.githubusercontent.com/assets/13276887/26746032/15ce704c-480b-11e7-9cbc-fc1bcbfa53c0.png)
