### PR TITLE
Fixes #132 - Makes websearch result tiles horizontally swipable

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "react-dom": "^15.5.4",
     "react-leaflet": "^1.1.6",
     "react-linkify": "^0.2.1",
+    "react-swipe": "^5.0.8",
     "react-tap-event-plugin": "^2.0.1",
-    "surge": "^0.19.0"
+    "surge": "^0.19.0",
+    "swipe-js-iso": "^2.0.3"
   },
   "devDependencies": {
     "enzyme": "^2.8.2",

--- a/src/components/MessageListItem.react.js
+++ b/src/components/MessageListItem.react.js
@@ -13,6 +13,7 @@ import {
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import { divIcon } from 'leaflet';
 import Paper from 'material-ui/Paper';
+import ReactSwipe from 'react-swipe';
 
 export function parseAndReplace(text) {
   return <Linkify properties={{target: '_blank'}}>
@@ -70,9 +71,6 @@ function drawWebSearchTiles(tilesData){
               </div>
             </Paper>
           </MuiThemeProvider>
-          <div>
-            <br/>
-          </div>
         </div>
       );
    }
@@ -90,9 +88,6 @@ function drawWebSearchTiles(tilesData){
           </div>
         </Paper>
       </MuiThemeProvider>
-      <div>
-        <br/>
-      </div>
     </div>
     );
 
@@ -238,7 +233,12 @@ class MessageListItem extends React.Component {
               <section className={messageContainerClasses}>
               <div className='message-text'>{replacedText}</div>
               <br/>
-              <div><div className='message-text'>{WebSearchTiles}</div></div>
+              <div><div className='message-text'>
+                <ReactSwipe className='carousel' key={WebSearchTiles.length}
+                  swipeOptions={{continuous: false}}>
+                  {WebSearchTiles}
+                </ReactSwipe>
+              </div></div>
               <div className='message-time'>
                 {message.date.toLocaleTimeString()}
               </div>


### PR DESCRIPTION
Fixes issue #132 

**Changes:**
Used react-swipe to make the websearch results tiles horizontally swipable

**Demo Link:**  http://webtileswipe.surge.sh/

**Sample Query:** search for *

**Screencast:**

![webtilesswipe](https://cloud.githubusercontent.com/assets/13276887/26752391/5a4f17c4-486c-11e7-9724-77d296fb3609.gif)
 
