### PR TITLE
Fixes #60: Send ISO 639-1 to server

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -52,9 +52,11 @@ export function createSUSIMessage(createdMessage, currentThreadID) {
     date: new Date(timestamp),
     isRead: true,
   };
+  // Fetching local browser language
+  var locale = document.documentElement.getAttribute('lang');
   // Ajax Success calls the Dispatcher to CREATE_SUSI_MESSAGE
   $.ajax({
-    url: 'http://api.asksusi.com/susi/chat.json?q=' + createdMessage.text,
+    url: 'http://api.asksusi.com/susi/chat.json?q='+createdMessage.text+'&language='+locale,
     dataType: 'jsonp',
     jsonpCallback: 'p',
     jsonp: 'callback',


### PR DESCRIPTION
**Fixes issue #60**

Changes:
- Fetches ISO 639-1 of the browser and send it to fetch reeponse

**Demo Link: http://susi.surge.sh**
Watch out for console. to see the response generated
Sample response
```
Object {query: "hi", count: 1, client_id: "aG9zdF8xNDEuMTAxLjk5LjE0NQ==", query_date: "2017-06-03T18:36:51.982Z", answers: Array(1)…}
answer_date
:
"2017-06-03T18:36:51.983Z"
answer_time
:
1
answers
:
Array(1)
client_id
:
"aG9zdF8xNDEuMTAxLjk5LjE0NQ=="
count
:
1
language
:
"en"
query
:
"hi"
query_date
:
"2017-06-03T18:36:51.982Z"
session
:
Object
```
Screenshots for the change: 
![screenshot from 2017-06-04 00 07 51](https://cloud.githubusercontent.com/assets/11540785/26756158/087f889a-48ba-11e7-972c-aee9dee963a0.png)
@isuruAb @uday96 @madhavrathi Please review