### PR TITLE
Fixes #147 - Setting to Toggle Chat History

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -230,3 +230,9 @@ export function ToggleSearch() {
     type: ActionTypes.SEARCH_MODE
   });
 };
+
+export function ToggleHistory() {
+  ChatAppDispatcher.dispatch({
+    type: ActionTypes.SHOW_HISTORY_CHANGED
+  });
+};

--- a/src/constants/ChatConstants.js
+++ b/src/constants/ChatConstants.js
@@ -11,7 +11,8 @@ export default {
     RECEIVE_RAW_MESSAGES: null,
     STORE_HISTORY_MESSAGE: null,
     THEME_CHANGED:null,
-    SEARCH_MODE: null
+    SEARCH_MODE: null,
+    SHOW_HISTORY_CHANGED: null
   })
 
 };

--- a/src/stores/HistoryStore.js
+++ b/src/stores/HistoryStore.js
@@ -1,0 +1,73 @@
+import ChatAppDispatcher from '../dispatcher/ChatAppDispatcher';
+import ChatConstants from '../constants/ChatConstants';
+import { EventEmitter } from 'events';
+import ThreadStore from '../stores/ThreadStore';
+
+let ActionTypes = ChatConstants.ActionTypes;
+let CHANGE_EVENT = 'change';
+
+let _history = {};
+
+let HistoryStore = {
+  ...EventEmitter.prototype,
+
+  emitChange() {
+    this.emit(CHANGE_EVENT);
+  },
+
+  /**
+   * @param {function} callback
+   */
+  addChangeListener(callback) {
+    this.on(CHANGE_EVENT, callback);
+  },
+
+  removeChangeListener(callback) {
+    this.removeListener(CHANGE_EVENT, callback);
+  },
+
+  /**
+   * @param {string} threadID
+   */
+  getAllForThread(threadID) {
+    let threadMessages = [];
+    for (let id in _history) {
+      if (_history[id].threadID === threadID) {
+        threadMessages.push(_history[id]);
+      }
+    }
+    threadMessages.sort((a, b) => {
+      if (a.date < b.date) {
+        return -1;
+      } else if (a.date > b.date) {
+        return 1;
+      }
+      return 0;
+    });
+    return threadMessages;
+  },
+
+  getAllForCurrentThread() {
+    return this.getAllForThread(ThreadStore.getCurrentID());
+  }
+
+};
+
+HistoryStore.dispatchToken = ChatAppDispatcher.register(action => {
+
+  switch(action.type) {
+
+    case ActionTypes.STORE_HISTORY_MESSAGE: {
+      let message = action.message;
+      _history[message.id] = message;
+      HistoryStore.emitChange();
+      break;
+    }
+
+    default:
+      // do nothing
+  }
+
+});
+
+export default HistoryStore;

--- a/src/stores/MessageStore.js
+++ b/src/stores/MessageStore.js
@@ -102,14 +102,6 @@ MessageStore.dispatchToken = ChatAppDispatcher.register(action => {
       MessageStore.emitChange();
       break;
     }
-
-    case ActionTypes.STORE_HISTORY_MESSAGE: {
-      let message = action.message;
-      _messages[message.id] = message;
-      MessageStore.emitChange();
-      break;
-    }
-
     default:
       // do nothing
   }

--- a/src/stores/SettingStore.js
+++ b/src/stores/SettingStore.js
@@ -7,6 +7,7 @@ let CHANGE_EVENT = 'change';
 
 let _searchMode = false;
 let _theme = true;
+let _showHistory = false;
 
 let SettingStore = {
     ...EventEmitter.prototype,
@@ -21,6 +22,10 @@ let SettingStore = {
 
     getTheme() {
         return _theme;
+    },
+
+    getHistoryMode(){
+        return _showHistory;
     },
 
     addChangeListener(callback) {
@@ -43,6 +48,11 @@ SettingStore.dispatchToken = ChatAppDispatcher.register(action => {
         }
         case ActionTypes.THEME_CHANGED: {
             _theme = !_theme;
+            SettingStore.emitChange();
+            break;
+        }
+        case ActionTypes.SHOW_HISTORY_CHANGED: {
+            _showHistory = !_showHistory;
             SettingStore.emitChange();
             break;
         }


### PR DESCRIPTION
Fixes issue #147 

**Changes:**
Added HistoryStore to store history message and Actions to show or hide history using a new setting option

**Demo Link:** http://togglechathistory.surge.sh/

PS: Ensure that there is history to be displayed while testing the feature. Check if cognitions are present in http://api.susi.ai/susi/memory.json

**Screencast:** 

![togglehistory-_online-video-cutter com_](https://cloud.githubusercontent.com/assets/13276887/26807575/d78a203a-4a74-11e7-84fc-742a4cf02377.gif)

