### PR TITLE
Fixes 151 - Loop Through Actions and display msgs

### DIFF
--- a/src/components/ChatApp.css
+++ b/src/components/ChatApp.css
@@ -270,7 +270,7 @@ textarea {
 }
 .leaflet-container {
   height: 150px;
-  width: 80%;
+  width: 250px;
   margin: 0 auto;
 }
 

--- a/src/components/MessageListItem.react.js
+++ b/src/components/MessageListItem.react.js
@@ -212,13 +212,62 @@ class MessageListItem extends React.Component {
       if(Object.keys(this.props.message.response).length > 0){
         let data = this.props.message.response;
         let actions = this.props.message.actions;
-
-        if (actions.indexOf('table')>=0) {
-            let actionIndex = actions.indexOf('table');
-            let coloumns = data.answers[0].actions[actionIndex].columns;
-            let table = drawTable(coloumns,data.answers[0].data);
-            return (
-                <li className='message-list-item'>
+        let listItems = []
+        actions.forEach((action,index)=>{
+          switch(action){
+            case 'answer': {
+              listItems.push(
+                <li className='message-list-item' key={action+index}>
+                  <section  className={messageContainerClasses}>
+                  <div className='message-text'>{replacedText}</div>
+                  <div className='message-time'>
+                    {message.date.toLocaleTimeString()}
+                  </div>
+                  </section>
+                </li>
+              );
+              break
+            }
+            case 'anchor': {
+              let link = data.answers[0].actions[index].link;
+              let text = data.answers[0].actions[index].text;
+              listItems.push(
+                <li className='message-list-item' key={action+index}>
+                  <section  className={messageContainerClasses}>
+                  <div className='message-text'>
+                    <a href={link} target='_blank'
+                      rel='noopener noreferrer'>{text}</a>
+                  </div>
+                  <div className='message-time'>
+                    {message.date.toLocaleTimeString()}
+                  </div>
+                  </section>
+                </li>
+              );
+              break
+            }
+            case 'map': {
+              let lat = parseFloat(data.answers[0].actions[index].latitude);
+              let lng = parseFloat(data.answers[0].actions[index].longitude);
+              let zoom = parseFloat(data.answers[0].actions[index].zoom);
+              let mymap = drawMap(lat,lng,zoom);
+              listItems.push(
+                <li className='message-list-item' key={action+index}>
+                  <section className={messageContainerClasses}>
+                  <div>{mymap}</div>
+                  <div className='message-time'>
+                    {message.date.toLocaleTimeString()}
+                  </div>
+                  </section>
+                </li>
+              );
+              break
+            }
+            case 'table': {
+              let coloumns = data.answers[0].actions[index].columns;
+              let table = drawTable(coloumns,data.answers[0].data);
+              listItems.push(
+                <li className='message-list-item' key={action+index}>
                   <section className={messageContainerClasses}>
                   <div className='message-text'>{replacedText}</div>
                   <div><div className='message-text'>{table}</div></div>
@@ -228,62 +277,51 @@ class MessageListItem extends React.Component {
                   </section>
                 </li>
               );
-        }
-        if (actions.indexOf('map')>=0) {
-          let actionIndex = actions.indexOf('map');
-          let lat = parseFloat(data.answers[0].actions[actionIndex].latitude);
-          let lng = parseFloat(data.answers[0].actions[actionIndex].longitude);
-          let zoom = parseFloat(data.answers[0].actions[actionIndex].zoom);
-          let mymap = drawMap(lat,lng,zoom);
-          return (
-                  <li className='message-list-item'>
+              break
+            }
+            case 'websearch': {
+              let results = this.props.message.websearchresults;
+              if(results.length === 0){
+                let noResultFound = 'NO Results Found'
+                listItems.push(
+                  <li className='message-list-item' key={action+index}>
                     <section className={messageContainerClasses}>
-                    <div className='message-text'>{replacedText}</div>
-                    <div>{mymap}</div>
+                    <div><div className='message-text'>
+                      <center>{noResultFound}</center></div></div>
                     <div className='message-time'>
                       {message.date.toLocaleTimeString()}
                     </div>
                     </section>
                   </li>
                 );
-        }
-        if (actions.indexOf('websearch')>=0) {
-          let results = this.props.message.websearchresults;
-          if(results.length === 0){
-            let noResultFound = 'NO Results Found'
-            return (
-              <li className='message-list-item'>
-                <section className={messageContainerClasses}>
-                <div className='message-text'>{replacedText}</div>
-                <br/>
-                <div><div className='message-text'>
-                  <center>{noResultFound}</center></div></div>
-                <div className='message-time'>
-                  {message.date.toLocaleTimeString()}
-                </div>
-                </section>
-              </li>
-            );
+              }
+              else{
+                let WebSearchTiles = drawWebSearchTiles(results);
+                listItems.push(
+                  <li className='message-list-item' key={action+index}>
+                    <section className={messageContainerClasses}>
+                    <div><div className='message-text'>
+                      <ReactSwipe className='carousel'
+                        key={WebSearchTiles.length}
+                        swipeOptions={{continuous: false}}>
+                        {WebSearchTiles}
+                      </ReactSwipe>
+                    </div></div>
+                    <div className='message-time'>
+                      {message.date.toLocaleTimeString()}
+                    </div>
+                    </section>
+                  </li>
+                );
+              }
+              break
+            }
+            default:
+              // do nothing
           }
-          let WebSearchTiles = drawWebSearchTiles(results);
-          return (
-            <li className='message-list-item'>
-              <section className={messageContainerClasses}>
-              <div className='message-text'>{replacedText}</div>
-              <br/>
-              <div><div className='message-text'>
-                <ReactSwipe className='carousel' key={WebSearchTiles.length}
-                  swipeOptions={{continuous: false}}>
-                  {WebSearchTiles}
-                </ReactSwipe>
-              </div></div>
-              <div className='message-time'>
-                {message.date.toLocaleTimeString()}
-              </div>
-              </section>
-            </li>
-          );
-        }
+        });
+
+        return (<div>{listItems}</div>);
       }
     }
 


### PR DESCRIPTION
Fixes issue #151 (partly)

**Changes:**
Instead of combining the data from all action elements and displaying a single response, we loop through each action element and render it.

As of now, every element is displayed with 0 delay.
Delay can be implemented creating a different issue.

**Demo Link:** http://loopactions.surge.sh/

**Sample Queries :**
1. Where is *
2. Search for * 

**Screenshots for the change:** 

![loopaction](https://cloud.githubusercontent.com/assets/13276887/26815745/b641a524-4aab-11e7-95cf-b82f665e2105.png)

