### PR TITLE
Fixes #174 - Remove text displayed along with table

### DIFF
--- a/src/components/MessageListItem.react.js
+++ b/src/components/MessageListItem.react.js
@@ -278,8 +278,6 @@ class MessageListItem extends React.Component {
               listItems.push(
                 <li className='message-list-item' key={action+index}>
                   <section className={messageContainerClasses}>
-                  <div className='message-text'>{replacedText}</div>
-                  <br />
                   <div><div className='message-text'>{table}</div></div>
                   <div className='message-time'>
                     {message.date.toLocaleTimeString()}


### PR DESCRIPTION
Fixes issue #174 

**Changes:** Removed the redundant text being displayed along with table

**Demo Link:** http://removetexttable.surge.sh/

Query: Susi, Please read the RSS feed from https://news.ycombinator.com/rss

**Screenshots for the change:**

![change](https://user-images.githubusercontent.com/13276887/26892563-5cc4e660-4bd6-11e7-83b2-a9690228c4e5.png)
 
