### PR TITLE
Fixes #185 - Using count from server response to limit results for table

### DIFF
--- a/src/components/MessageListItem.react.js
+++ b/src/components/MessageListItem.react.js
@@ -98,7 +98,7 @@ function drawWebSearchTiles(tilesData){
   return resultTiles;
 }
 
-function drawTable(coloumns,tableData){
+function drawTable(coloumns,tableData,count){
   let parseKeys;
   let showColName = true;
   if(coloumns.constructor === Array){
@@ -111,7 +111,13 @@ function drawTable(coloumns,tableData){
   let tableheader = parseKeys.map((key,i) =>{
     return(<TableHeaderColumn key={i}>{coloumns[key]}</TableHeaderColumn>);
   });
-  let rows = tableData.map((eachrow,j) => {
+  let rowCount = tableData.length;
+  if(count > -1){
+    rowCount = Math.min(count,tableData.length);
+  }
+  let rows = [];
+  for (var j=0; j < rowCount; j++) {
+    let eachrow = tableData[j];
     let rowcols = parseKeys.map((key,i) =>{
       return(
         <TableRowColumn key={i}>
@@ -121,10 +127,10 @@ function drawTable(coloumns,tableData){
         </TableRowColumn>
       );
     });
-    return(
+    rows.push(
       <TableRow key={j}>{rowcols}</TableRow>
     );
-  });
+  }
 
   const table =
   <MuiThemeProvider>
@@ -275,7 +281,8 @@ class MessageListItem extends React.Component {
             }
             case 'table': {
               let coloumns = data.answers[0].actions[index].columns;
-              let table = drawTable(coloumns,data.answers[0].data);
+              let count = data.answers[0].actions[index].count;
+              let table = drawTable(coloumns,data.answers[0].data,count);
               listItems.push(
                 <li className='message-list-item' key={action+index}>
                   <section className={messageContainerClasses}>


### PR DESCRIPTION
Fixes issue #185 

**Changes:**
Used count attribute from server response to limit the table rows
count = -1 => infinite or show all results

**Demo Link:**  http://tablelimit.surge.sh/

**Sample Query:** universities in germany (returns count = -1)
