### PR TITLE
Fixes #179 - Sending location info of client

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -9,6 +9,8 @@ import Cookies from 'universal-cookie';
 const cookies = new Cookies();
 let ActionTypes = ChatConstants.ActionTypes;
 
+let _Location = null;
+
 export function createMessage(text, currentThreadID) {
   let message = ChatMessageUtils.getCreatedMessageData(text, currentThreadID);
   ChatAppDispatcher.dispatch({
@@ -39,6 +41,28 @@ export function receiveAll(rawMessages) {
     rawMessages
   });
 };
+
+export function getLocation(){
+  $.ajax({
+    url: 'http://ipinfo.io/json',
+    dataType: 'jsonp',
+    crossDomain: true,
+    timeout: 3000,
+    async: false,
+    success: function (response) {
+      let loc = response.loc.split(',');
+      _Location = {
+        lat: loc[0],
+        lng: loc[1],
+      };
+    },
+    error: function(errorThrown){
+      console.log(errorThrown);
+      _Location = null;
+    }
+  });
+}
+
 export function createSUSIMessage(createdMessage, currentThreadID) {
   var timestamp = Date.now();
 
@@ -61,10 +85,12 @@ export function createSUSIMessage(createdMessage, currentThreadID) {
   if(cookies.get('loggedIn')===null || cookies.get('loggedIn')===undefined){
     url = 'http://api.asksusi.com/susi/chat.json?q='+createdMessage.text+'&language='+locale;
   }
-    else{
-      url = 'http://api.asksusi.com/susi/chat.json?q='+createdMessage.text+'&language='+locale+'&access_token='+cookies.get('loggedIn');
-    }
-    console.log(url);
+  else{
+    url = 'http://api.asksusi.com/susi/chat.json?q='+createdMessage.text+'&language='+locale+'&access_token='+cookies.get('loggedIn');
+  }
+  if(_Location){
+    url = url+'&latitude='+_Location.lat+'&longitude='+_Location.lng;
+  }
   $.ajax({
     url: url,
     dataType: 'jsonp',

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import {
 	hashHistory
 } from 'react-router-dom';
 
+ChatWebAPIUtils.getLocation();
 ChatWebAPIUtils.getHistory();
 ChatWebAPIUtils.getAllMessages();
 

--- a/src/utils/ChatWebAPIUtils.js
+++ b/src/utils/ChatWebAPIUtils.js
@@ -22,3 +22,7 @@ export function getAllMessages() {
 export function getHistory(){
 	Actions.getHistory();
 }
+
+export function getLocation(){
+  Actions.getLocation();
+}


### PR DESCRIPTION
Fixes issue #179 

**Changes:**
Added an action to get location info of the client based on IP address.
Used API : http://ipinfo.io/ (similar to android client)

**Demo Link:** http://clientlocation.surge.sh/

**Screenshot:** 

![whereami](https://user-images.githubusercontent.com/13276887/26985003-3c87860c-4d5f-11e7-8f8a-e9e0bb50b0b1.png)

@rishiraj824 @isuruAb @madhavrathi please review