### PR TITLE
Fixes #193:Fetch old messages as soon as one is logged in

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -134,9 +134,17 @@ export function createSUSIMessage(createdMessage, currentThreadID) {
 };
 
 export function getHistory() {
-
+  let url = '';
+  if(cookies.get('loggedIn')===null || cookies.get('loggedIn')===undefined){
+    url = 'http://api.susi.ai/susi/memory.json';
+    console.log(url);
+  }
+    else{
+      url = 'http://api.susi.ai/susi/memory.json?access_token='+cookies.get('loggedIn');
+      console.log(url);
+    }
   $.ajax({
-    url: 'http://api.susi.ai/susi/memory.json',
+    url: url,
     dataType: 'jsonp',
     crossDomain: true,
     timeout: 3000,


### PR DESCRIPTION
**Fixes issue #193**
Changes-
- Now History will be fetched, to maintain a consistent chat history across all devices.

Demo Link: 
http://susi.surge.sh

@uday96 @madhavrathi @isuruAb Please review


