### PR TITLE
Fixes #224 - Fix route from forgot password to login

### DIFF
--- a/src/components/Auth/ForgotPassword/ForgotPassword.react.js
+++ b/src/components/Auth/ForgotPassword/ForgotPassword.react.js
@@ -28,7 +28,7 @@ class ForgotPassword extends Component {
   	handleClose(){
   		let state = this.state;
   		if(state.success){
-  			this.props.history.push('/login');
+		   this.props.history.push('/',{showLogin:true});
   		}
   		else{
   			this.setState({

--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -66,6 +66,7 @@ class Login extends Component {
 		let state = this.state;
 		if (state.success) {
 			cookies.set('loggedIn', loggedIn, { path: '/', maxAge: time });
+			this.props.history.push('/',{showLogin:false});
 			window.location.reload();
 		}
 		else {

--- a/src/components/ChatApp/ChatApp.react.js
+++ b/src/components/ChatApp/ChatApp.react.js
@@ -14,11 +14,9 @@ export default class ChatApp extends React.Component {
    }
 
   render() {
-
     return (
-
       <div className='chatapp'>
-        <MessageSection />
+        <MessageSection {...this.props}/>
       </div>
     );
   }

--- a/src/components/ChatApp/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection.react.js
@@ -89,12 +89,15 @@ class MessageSection extends Component {
     super(props);
     this.state = getStateFromStores();
   }
+
   handleOpen = () => {
       this.setState({open: true});
   };
+
   handleClose = () => {
     this.setState({open: false});
   };
+
   componentDidMount() {
     this._scrollToBottom();
     MessageStore.addChangeListener(this._onChange.bind(this));
@@ -150,6 +153,16 @@ class MessageSection extends Component {
   }
 
   componentWillMount() {
+
+    if(this.props.location){
+      if(this.props.location.state){
+        if(this.props.location.state.hasOwnProperty('showLogin')){
+          let showLogin = this.props.location.state.showLogin;
+          this.setState({open:showLogin});
+        }
+      }
+    }
+
     SettingStore.on('change', () => {
       this.setState({
         darkTheme: SettingStore.getTheme()
@@ -162,7 +175,9 @@ class MessageSection extends Component {
       }
     })
   }
+
   render() {
+
     const bodyStyle ={
       'padding' : 0
     }
@@ -232,7 +247,7 @@ class MessageSection extends Component {
             autoScrollBodyContent={true}
             bodyStyle={bodyStyle}
             onRequestClose={this.handleClose}>
-                      <div><Login /></div>
+                      <div><Login {...this.props} /></div>
             </Dialog>
           </div>
         );
@@ -285,5 +300,9 @@ function change() {
 
 
 Logged.muiName = 'IconMenu';
+
+MessageSection.propTypes = {
+  location: PropTypes.object,
+};
 
 export default addUrlProps({ urlPropsQueryConfig })(MessageSection);


### PR DESCRIPTION
Fixes issue #224 

**Changes:**
Upon forgot password success, the user is now redirected to the landing page with the login dialog opened.

**Demo Link:**  http://loginroute.surge.sh/

**Screencast:**

![loginroute](https://user-images.githubusercontent.com/13276887/27012521-b15aaa32-4eee-11e7-8fb1-459c022fdbe7.gif)

