### PR TITLE
Fixes #240 - Add cancel button to forgot password form

### DIFF
--- a/src/components/Auth/ForgotPassword/ForgotPassword.react.js
+++ b/src/components/Auth/ForgotPassword/ForgotPassword.react.js
@@ -24,6 +24,12 @@ class ForgotPassword extends Component {
 		this.handleChange = this.handleChange.bind(this);
 		this.handleSubmit = this.handleSubmit.bind(this);
 		this.handleClose = this.handleClose.bind(this);
+		this.handleCancel = this.handleCancel.bind(this);
+	}
+
+	handleCancel(){
+		this.props.history.push('/', { showLogin: false });
+		window.location.reload();
 	}
 
 	handleClose() {
@@ -131,6 +137,15 @@ class ForgotPassword extends Component {
 								disabled={!this.state.validForm} />
 						</div>
 					</form>
+					<br/>
+					<RaisedButton
+				      label="Cancel"
+				      backgroundColor={
+				        SettingStore.getTheme() ? '#607D8B' : '#19314B'}
+				      labelColor="#fff"
+				      keyboardFocused={true}
+				      onTouchTap={this.handleCancel}
+				    />
 				</Paper>
 				{this.state.msg && (
 					<div><Dialog

--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -167,7 +167,7 @@ class Login extends Component {
 							</Link>
 						</div>
 						<div>
-							<Link to={'/'} >
+							<Link to={'/logout'} >
 								<RaisedButton
 									label='Chat Anonymously'
 									backgroundColor={
@@ -178,6 +178,7 @@ class Login extends Component {
 					</form>
 				</Paper>
 			</div>);
+
 	};
 }
 

--- a/src/components/Auth/SignUp/SignUp.react.js
+++ b/src/components/Auth/SignUp/SignUp.react.js
@@ -154,17 +154,22 @@ export default class SignUp extends Component {
     handleClose = () => {
         this.setState({ open: false });
     }
+
         render() {
+
             const styles = {
                 'margin': '60px auto',
                 'width': '100%',
                 'padding': '20px',
                 'textAlign': 'center'
             }
+
             const actions =
                 <FlatButton
-                    label="OK"
-                    primary={true}
+                    label="Cancel"
+                    backgroundColor={
+                        SettingStore.getTheme() ? '#607D8B' : '#19314B'}
+                    labelStyle={{color:'#fff'}}
                     onTouchTap={this.handleClose}
                 />;
 
@@ -238,6 +243,7 @@ SettingStore.getTheme() ? '#607D8B' : '#19314B'}
         );
     };
 }
+
 SignUp.propTypes = {
     history: PropTypes.object
 }


### PR DESCRIPTION
Fixes issue #240 

**Changes:**
 * Added a cancel button to redirect from forgot password page to landing page
 * Fixed chat anonymously route in login dialog

If we dont reload the window, we get a setState error, so i added window.reload() after redirecting to "/"

**Demo Link:**  http://cancelbtn.surge.sh/

**Screenshots:** 

![cancel](https://user-images.githubusercontent.com/13276887/27049708-bf911890-4fcd-11e7-838a-9dcd299366cb.png)

