### PR TITLE
Fixes #253 - Show table content on hover

### DIFF
--- a/src/components/ChatApp/MessageListItem.react.js
+++ b/src/components/ChatApp/MessageListItem.react.js
@@ -139,7 +139,9 @@ function drawTable(coloumns,tableData,count){
       return(
         <TableRowColumn key={i}>
           <Linkify properties={{target:'_blank'}}>
-            {eachrow[key]}
+            <abbr title={eachrow[key]}>
+              {eachrow[key]}
+            </abbr>
           </Linkify>
         </TableRowColumn>
       );


### PR DESCRIPTION
Fixes issue #253 

**Changes:**
* Added `<abbr> tag` to elements in table to show the entire cell content on hover

**Demo Link:**  http://tablehover.surge.sh/

**Screenshots for the change:** 

![table](https://user-images.githubusercontent.com/13276887/27166923-82b44f6a-51bb-11e7-86c1-ba9dfe2971ec.png)

