### PR TITLE
Fixes #272 - Fix default server option in settings dialog

### DIFF
--- a/src/actions/Settings.actions.js
+++ b/src/actions/Settings.actions.js
@@ -1,7 +1,9 @@
 import UserPreferencesStore from '../stores/UserPreferencesStore';
 import ChatAppDispatcher from '../dispatcher/ChatAppDispatcher';
 import ChatConstants from '../constants/ChatConstants';
+
 let ActionTypes = ChatConstants.ActionTypes;
+
 export function getDefaults() {
   return UserPreferencesStore.getPreferences();
 }
@@ -22,6 +24,13 @@ export function setDefaultTheme(defaultTheme){
   });
 }
 
+export function setDefaultServer(defaultServer){
+  ChatAppDispatcher.dispatch({
+    type: ActionTypes.DEFAULT_SERVER_CHANGED,
+    defaultServer
+  });
+}
+
 export function themeChanged(theme) {
   ChatAppDispatcher.dispatch({
     type: ActionTypes.THEME_CHANGED,
@@ -34,5 +43,3 @@ export function ToggleSearch() {
     type: ActionTypes.SEARCH_MODE
   });
 };
-
-

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,27 +1,29 @@
 // imports
-import { getLocation, createSUSIMessage } from './API.actions';
-import { getHistory } from './History.actions';
-import { createMessage,
-  receiveCreatedMessage,
-  clickThread,
-  receiveAll } from './ChatApp.actions';
-import { getDefaults,
-         setDefaults,
-         setDefaultTheme,
-       ToggledSearch,
+import {  getLocation, createSUSIMessage } from './API.actions';
+import {  getHistory } from './History.actions';
+import {  createMessage,
+          receiveCreatedMessage,
+          clickThread,
+          receiveAll } from './ChatApp.actions';
+import {  getDefaults,
+          setDefaults,
+          setDefaultTheme,
+          setDefaultServer,
+          ToggleSearch,
           themeChanged} from './Settings.actions';
 
 // exports
 export { getLocation, createSUSIMessage }
 export { getHistory }
 
-export { createMessage,
-  receiveCreatedMessage,
-  clickThread,
-  receiveAll }
+export {  createMessage,
+          receiveCreatedMessage,
+          clickThread,
+          receiveAll }
 
 export { getDefaults,
-  setDefaults,
-  setDefaultTheme,
-  ToggledSearch,
-  themeChanged }
+         setDefaults,
+         setDefaultTheme,
+         setDefaultServer,
+         ToggleSearch,
+         themeChanged }

--- a/src/components/ChatApp/Settings.react.js
+++ b/src/components/ChatApp/Settings.react.js
@@ -8,18 +8,23 @@ import * as Actions from '../../actions/';
 import PropTypes from 'prop-types';
 import TextField from 'material-ui/TextField';
 import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
+import UserPreferencesStore from '../../stores/UserPreferencesStore';
 
 class Settings extends Component {
 
 	constructor(props) {
 		super(props);
+		let defaults = UserPreferencesStore.getPreferences();
+		let defaultServer = defaults.Server;
+		let defaultTheme = defaults.Theme;
+		console.log(defaultTheme);
 		this.state = {
-			theme: 'light',
-			server: 'http://api.susi.ai',
+			theme: defaultTheme,
+			server: defaultServer,
 			serverUrl: '',
             serverFieldError: false,
             checked: false,
-			validForm: false
+			validForm: true
 		};
 		this.handleSubmit = this.handleSubmit.bind(this);
 		this.handleChange = this.handleChange.bind(this);
@@ -31,12 +36,19 @@ class Settings extends Component {
 		e.preventDefault();
 		let newDefaultTheme = this.state.theme;
 		let newDefaultServer = this.state.server;
+		if(newDefaultServer.slice(-1)==='/'){
+			newDefaultServer = newDefaultServer.slice(0,-1);
+		}
+		console.log(newDefaultServer);
 		Actions.setDefaultTheme(newDefaultTheme);
 		Actions.setDefaultServer(newDefaultServer);
 		this.props.history.push('/');
 		window.location.reload();
 	}
-	 handleSelectChange = (event, index, value) => this.setState({theme:value});
+
+	handleSelectChange(event, index, value){
+		this.setState({theme:value});
+	}
 
 	handleChange(event) {
         let state = this.state;
@@ -48,19 +60,20 @@ class Settings extends Component {
 		else if (event.target.value === 'standardServer') {
 			state.checked = false;
 			state.serverFieldError = false;
+			let defaults = UserPreferencesStore.getPreferences();
+			let standardServerURL = defaults.StandardServer;
+			state.server = standardServerURL;
 		}
 		else if (event.target.name === 'serverUrl'){
-			console.log(event.target.value);
         	serverUrl = event.target.value;
         	let validServerUrl =
 /(http|ftp|https):\/\/[\w-]+(\.[\w-]+)+([\w.,@?^=%&amp;:~+#-]*[\w@?^=%&amp;~+#-])?/i
         	.test(serverUrl);
 			state.server = serverUrl;
-			console.log(state)
 			state.serverFieldError = !(serverUrl && validServerUrl);
         }
 
-        if (this.state.serverFieldError) {
+        if (state.serverFieldError) {
         	this.customServerMessage
         	= 'Enter a valid URL';
         }
@@ -68,14 +81,13 @@ class Settings extends Component {
         	this.customServerMessage = '';
         }
 
-    	if (!state.serverFieldError)
+    	if (!state.serverFieldError || !state.checked)
     	{
     		state.validForm = true;
     	}
         else {
         	state.validForm = false;
         }
-        console.log(state);
 		this.setState(state);
 	};
 
@@ -85,6 +97,7 @@ class Settings extends Component {
 			'textAlign': 'center',
 			'padding': '10px'
 		}
+
 		const radioButtonStyles = {
 		  block: {
 		    maxWidth: 250,

--- a/src/stores/UserPreferencesStore.js
+++ b/src/stores/UserPreferencesStore.js
@@ -7,7 +7,8 @@ let CHANGE_EVENT = 'change';
 
 let _defaults = {
     Theme: 'light',
-    Server: 'http://api.susi.ai'
+    Server: 'http://api.susi.ai',
+    StandardServer: 'http://api.susi.ai'
 };
 
 let UserPreferencesStore = {


### PR DESCRIPTION
Fixes issue #272 

**Changes:**
* Added action to set default server
  Now upon clicking `reset defaults` in settings dialog, we can see the defaults printed in console.log and there is no error.

**What needs to be implemented yet:**

  To actually test the default settings, the support to push and pull userdata to and from server and accordingly updating the userpreferences store must be implemented first which is still not implemented.

**Demo Link:**   http://setdefserver.surge.sh/

**Screenshots for the change:** 

![con](https://user-images.githubusercontent.com/13276887/27217747-ccf72f9c-5298-11e7-99c3-5f0548dbf4f5.png)

