### PR TITLE
Fixes #295 - Remove Change Theme as drop down and include it in settings

### DIFF
--- a/src/actions/Settings.actions.js
+++ b/src/actions/Settings.actions.js
@@ -17,13 +17,6 @@ export function setDefaults() {
   });
 }
 
-export function setDefaultTheme(defaultTheme){
-  ChatAppDispatcher.dispatch({
-    type: ActionTypes.DEFAULT_THEME_CHANGED,
-    defaultTheme
-  });
-}
-
 export function setDefaultServer(defaultServer){
   ChatAppDispatcher.dispatch({
     type: ActionTypes.DEFAULT_SERVER_CHANGED,

--- a/src/components/Auth/ForgotPassword/ForgotPassword.react.js
+++ b/src/components/Auth/ForgotPassword/ForgotPassword.react.js
@@ -7,7 +7,6 @@ import FlatButton from 'material-ui/FlatButton';
 import './ForgotPassword.css';
 import $ from 'jquery';
 import PropTypes from 'prop-types'
-import SettingStore from '../../../stores/SettingStore';
 import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
 import UserPreferencesStore from '../../../stores/UserPreferencesStore';
 
@@ -28,20 +27,16 @@ class ForgotPassword extends Component {
 			validForm:false
 		};
 
-		this.handleChange = this.handleChange.bind(this);
-		this.handleSubmit = this.handleSubmit.bind(this);
-		this.handleClose = this.handleClose.bind(this);
-		this.handleCancel = this.handleCancel.bind(this);
 		this.emailErrorMessage = '';
 		this.customServerMessage = '';
 	}
 
-	handleCancel(){
+	handleCancel = () => {
 		this.props.history.push('/', { showLogin: false });
 		window.location.reload();
 	}
 
-	handleClose() {
+	handleClose = () => {
 		let state = this.state;
 		if (state.success) {
 			this.props.history.push('/', { showLogin: true });
@@ -61,7 +56,7 @@ class ForgotPassword extends Component {
 		}
 	};
 
-	handleChange(event) {
+	handleChange = (event) => {
 		let email;
         let serverUrl;
         let state = this.state;
@@ -118,7 +113,7 @@ class ForgotPassword extends Component {
         this.setState(state);
 	};
 
-	handleSubmit(event) {
+	handleSubmit = (event) => {
 		event.preventDefault();
 
 		let email = this.state.email.trim();
@@ -185,7 +180,7 @@ class ForgotPassword extends Component {
 			<FlatButton
 				label="OK"
 				backgroundColor={
-					SettingStore.getTheme() ? '#607D8B' : '#19314B'}
+					UserPreferencesStore.getTheme()==='light' ? '#607D8B' : '#19314B'}
 				labelStyle={{ color: '#fff' }}
 				onTouchTap={this.handleClose}
 			/>;
@@ -236,7 +231,7 @@ class ForgotPassword extends Component {
 								type="submit"
 								label="Reset"
 								backgroundColor={
-									SettingStore.getTheme() ? '#607D8B' : '#19314B'}
+									UserPreferencesStore.getTheme()==='light' ? '#607D8B' : '#19314B'}
 								labelColor="#fff"
 								disabled={!this.state.validForm} />
 						</div>
@@ -245,7 +240,7 @@ class ForgotPassword extends Component {
 					<RaisedButton
 				      label="Cancel"
 				      backgroundColor={
-				        SettingStore.getTheme() ? '#607D8B' : '#19314B'}
+				        UserPreferencesStore.getTheme()==='light' ? '#607D8B' : '#19314B'}
 				      labelColor="#fff"
 				      keyboardFocused={true}
 				      onTouchTap={this.handleCancel}

--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -9,10 +9,10 @@ import $ from 'jquery';
 import PropTypes  from 'prop-types';
 import Cookies from 'universal-cookie';
 import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
-import SettingStore from '../../../stores/SettingStore';
 import UserPreferencesStore from '../../../stores/UserPreferencesStore';
 
 const cookies = new Cookies();
+
 class Login extends Component {
 	constructor(props) {
 		super(props);
@@ -28,15 +28,12 @@ class Login extends Component {
             serverFieldError: false,
             checked: false
 		};
-		this.handleChange = this.handleChange.bind(this);
-		this.handleSubmit = this.handleSubmit.bind(this);
-		this.handleOnSubmit = this.handleOnSubmit.bind(this);
 		this.emailErrorMessage = '';
         this.passwordErrorMessage = '';
         this.customServerMessage = '';
 	}
 
-	handleSubmit(e) {
+	handleSubmit = (e) => {
 		e.preventDefault();
 
 		var email = this.state.email.trim();
@@ -60,7 +57,7 @@ class Login extends Component {
 		let loginEndPoint =
 			BASE_URL+'/aaa/login.json?type=access-token&login=' +
 			this.state.email + '&password=' + this.state.password;
-		console.log(loginEndPoint);
+
 		if (email && validEmail) {
 			$.ajax({
 				url: loginEndPoint,
@@ -91,7 +88,8 @@ class Login extends Component {
 			});
 		}
 	}
-	handleChange(event) {
+
+	handleChange = (event) => {
 		let email;
         let password;
         let serverUrl;
@@ -148,10 +146,10 @@ class Login extends Component {
         else{
         	this.customServerMessage = '';
         }
-    if (!state.emailError && !state.passwordError && !state.serverFieldError)
-    {
-    	state.validForm = true;
-    }
+	    if (!state.emailError && !state.passwordError && !state.serverFieldError)
+	    {
+	    	state.validForm = true;
+	    }
         else {
         	state.validForm = false;
         }
@@ -159,7 +157,7 @@ class Login extends Component {
 		this.setState(state);
 	}
 
-	handleOnSubmit(loggedIn, time) {
+	handleOnSubmit = (loggedIn, time) => {
 		let state = this.state;
 		if (state.success) {
 			cookies.set('loggedIn', loggedIn, { path: '/', maxAge: time });
@@ -227,7 +225,7 @@ class Login extends Component {
 							  marginTop: '10px',
 							  maxWidth:'200px',
 							  flexWrap: 'wrap',
-							margin: 'auto'}}
+							  margin: 'auto'}}
 							 name="server" onChange={this.handleChange}
 							 defaultSelected="standardServer">
 							<RadioButton
@@ -253,7 +251,7 @@ class Login extends Component {
 								label="Login"
 								type="submit"
 								backgroundColor={
-									SettingStore.getTheme() ? '#607D8B' : '#19314B'}
+									UserPreferencesStore.getTheme()==='light' ? '#607D8B' : '#19314B'}
 								labelColor="#fff"
 								disabled={!this.state.validForm} />
 						</div>
@@ -270,7 +268,7 @@ class Login extends Component {
 								<RaisedButton
 									label='Chat Anonymously'
 									backgroundColor={
-										SettingStore.getTheme() ? '#607D8B' : '#19314B'}
+										UserPreferencesStore.getTheme()==='light' ? '#607D8B' : '#19314B'}
 									labelColor="#fff" />
 							</Link>
 						</div>

--- a/src/components/Auth/SignUp/SignUp.react.js
+++ b/src/components/Auth/SignUp/SignUp.react.js
@@ -8,7 +8,6 @@ import PasswordField from 'material-ui-password-field';
 import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import PropTypes from 'prop-types';
-import SettingStore from '../../../stores/SettingStore';
 import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
 import UserPreferencesStore from '../../../stores/UserPreferencesStore';
 import Login from '../Login/Login.react';
@@ -34,9 +33,6 @@ export default class SignUp extends Component {
             serverFieldError: false,
         };
 
-        this.handleChange = this.handleChange.bind(this);
-        this.handleSubmit = this.handleSubmit.bind(this);
-        this.handleClose = this.handleClose.bind(this);
         this.emailErrorMessage = '';
         this.passwordErrorMessage = '';
         this.passwordConfirmErrorMessage = '';
@@ -49,7 +45,7 @@ export default class SignUp extends Component {
         }
     }
 
-    handleClose() {
+    handleClose = () => {
         let state = this.state;
 
         if (state.success) {
@@ -73,9 +69,9 @@ export default class SignUp extends Component {
                 open: false
             });
         }
-    };
+    }
 
-    handleChange(event) {
+    handleChange = (event) => {
         let email;
         let password;
         let confirmPassword;
@@ -167,9 +163,9 @@ export default class SignUp extends Component {
         else{
             this.setState({validForm: true});
         }
-    };
+    }
 
-    handleSubmit(event) {
+    handleSubmit = (event) => {
         event.preventDefault();
 
         let defaults = UserPreferencesStore.getPreferences();
@@ -186,7 +182,7 @@ export default class SignUp extends Component {
         let signupEndPoint =
             BASE_URL+'/aaa/signup.json?signup=' + this.state.email +
             '&password=' + this.state.passwordValue;
-        console.log(signupEndPoint);
+
         if (!this.state.emailError && !this.state.passwordConfirmError
             && !this.state.serverFieldError) {
             $.ajax({
@@ -254,7 +250,7 @@ export default class SignUp extends Component {
             <FlatButton
                 label="OK"
                 backgroundColor={
-                    SettingStore.getTheme() ? '#607D8B' : '#19314B'}
+                    UserPreferencesStore.getTheme()==='light' ? '#607D8B' : '#19314B'}
                 labelStyle={{ color: '#fff' }}
                 onTouchTap={this.handleClose}
             />;
@@ -323,7 +319,8 @@ export default class SignUp extends Component {
                                 type="submit"
                                 disabled={!this.state.validForm}
                                 backgroundColor={
-                                    SettingStore.getTheme() ? '#607D8B' : '#19314B'}
+                                    UserPreferencesStore.getTheme()==='light'
+                                    ? '#607D8B' : '#19314B'}
                                 labelColor="#fff" />
                         </div>
                         <h1>OR</h1>
@@ -334,7 +331,8 @@ export default class SignUp extends Component {
                                 label='Login'
 
                                 backgroundColor={
-                                    SettingStore.getTheme() ? '#607D8B' : '#19314B'}
+                                    UserPreferencesStore.getTheme()==='light'
+                                    ? '#607D8B' : '#19314B'}
                                 labelColor="#fff" />
                         </div>
                     </form>

--- a/src/components/ChatApp/HardwareComponent.js
+++ b/src/components/ChatApp/HardwareComponent.js
@@ -3,7 +3,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 import PropTypes from 'prop-types';
 import TextField from 'material-ui/TextField';
 import Paper from 'material-ui/Paper';
-import SettingStore from '../../stores/SettingStore';
+import UserPreferencesStore from '../../stores/UserPreferencesStore';
 
 class HardwareComponent extends Component {
 
@@ -16,17 +16,15 @@ class HardwareComponent extends Component {
 			validForm: true,
 			open: false
 		};
-		this.handleSubmit = this.handleSubmit.bind(this);
-		this.handleChange = this.handleChange.bind(this);
 		this.customServerMessage = '';
 	}
 
-	handleSubmit(e){
+	handleSubmit = (e) => {
 		e.preventDefault();
 		// Handle Hardware Logic
 	}
 
-	handleChange(event) {
+	handleChange = (event) => {
         let state = this.state;
         let serverUrl;
         if (event.target.name === 'serverUrl'){
@@ -79,7 +77,7 @@ class HardwareComponent extends Component {
 							type="submit"
 							disabled={!this.state.validForm}
 							backgroundColor={
-								SettingStore.getTheme() ? '#607D8B' : '#19314B'}
+								UserPreferencesStore.getTheme()==='light' ? '#607D8B' : '#19314B'}
 							labelColor="#fff"
 						/>
 					</div>

--- a/src/components/ChatApp/MessageComposer.react.js
+++ b/src/components/ChatApp/MessageComposer.react.js
@@ -1,9 +1,8 @@
-
 import * as Actions from '../../actions/';
 import React,{Component} from 'react';
 import PropTypes from 'prop-types';
 import Send from 'material-ui/svg-icons/content/send';
-import SettingStore from '../../stores/SettingStore';
+import UserPreferencesStore from '../../stores/UserPreferencesStore';
 import IconButton from 'material-ui/IconButton';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 injectTapEventPlugin();
@@ -42,7 +41,7 @@ class MessageComposer extends Component {
           style={{background:this.props.textarea}}
         />
         <IconButton
-          iconStyle={{fill:SettingStore.getTheme()?'#607D8B':'#fff',
+          iconStyle={{fill:UserPreferencesStore.getTheme()==='light'?'#607D8B':'#fff',
           marginTop:'6px'}}
           onTouchTap={this._onClickButton.bind(this)}
           style={style}>

--- a/src/components/ChatApp/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection.react.js
@@ -7,11 +7,11 @@ import React, { Component } from 'react';
 import ThreadStore from '../../stores/ThreadStore';
 import * as Actions from '../../actions/';
 import SettingStore from '../../stores/SettingStore';
+import UserPreferencesStore from '../../stores/UserPreferencesStore';
 import SearchIcon from 'material-ui/svg-icons/action/search';
 import AppBar from 'material-ui/AppBar';
 import MenuItem from 'material-ui/MenuItem';
 import IconButton from 'material-ui/IconButton';
-import ArrowDropLeft from 'material-ui/svg-icons/navigation/arrow-back';
 import IconMenu from 'material-ui/IconMenu';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import PropTypes from 'prop-types';
@@ -30,14 +30,14 @@ function getStateFromStores() {
   return {
     messages: MessageStore.getAllForCurrentThread(),
     thread: ThreadStore.getCurrent(),
-    darkTheme: SettingStore.getTheme(),
+    currTheme: UserPreferencesStore.getTheme(),
     search: SettingStore.getSearchMode(),
     showLoading: MessageStore.getLoadStatus(),
     open: false,
     showSettings: false,
     showThemeChanger: false,
     showHardware: false,
-    header: '#607d8b',
+    header: UserPreferencesStore.getTheme()==='light' ? '#607D8B' : '#19314B',
     pane: '',
     textarea: '',
     composer:'',
@@ -53,7 +53,6 @@ function getMessageListItem(message) {
     />
   );
 }
-
 
 function getLoadingGIF() {
   let messageContainerClasses = 'message-container SUSI';
@@ -91,15 +90,16 @@ class MessageSection extends Component {
 
   static propTypes = {
     dream: PropTypes.string
-  }
+  };
 
   static defaultProps = {
     dream: ''
-  }
+  };
 
   state = {
     open: false
   };
+
   constructor(props) {
     super(props);
     this.state = getStateFromStores();
@@ -131,11 +131,11 @@ class MessageSection extends Component {
 
      }
      this.setState(state);
-  };
+  }
 
   handleOpen = () => {
     this.setState({ open: true });
-  };
+  }
 
   handleClose = () => {
     this.setState({
@@ -144,17 +144,30 @@ class MessageSection extends Component {
       showThemeChanger: false,
       showHardware: false
     });
-  };
+  }
 
   handleThemeChanger = () => {
-    this.setState({showThemeChanger: true})
+    this.setState({showThemeChanger: true});
   }
 
   handleSettings = () => {
     this.setState({showSettings: true});
   }
+
   handleHardware = () => {
     this.setState({showHardware: true});
+  }
+
+  changeTheme = (newTheme) => {
+    if(this.state.currTheme !== newTheme){
+      Actions.themeChanged(newTheme);
+    }
+  }
+
+  implementSettings = (values) => {
+    this.setState({showSettings: false});
+    this.changeTheme(values.theme);
+    // Actions.setDefaultServer(values.server);
   }
 
   componentDidMount() {
@@ -176,29 +189,15 @@ class MessageSection extends Component {
         >
           <MenuItem primaryText="Settings"
             onClick={this.handleSettings} />
-          <MenuItem primaryText="Chat Anonymously"
-            containerElement={<Link to="/logout" />} />
+          <MenuItem primaryText="Custom Theme"
+            key="custom"
+            onClick={this.handleThemeChanger} />
           <MenuItem primaryText="Connect to SUSI Hardware"
             onClick={this.handleHardware} />
+          <MenuItem primaryText="Chat Anonymously"
+            containerElement={<Link to="/logout" />} />
           <MenuItem primaryText="Logout"
             containerElement={<Link to="/logout" />} />
-            <MenuItem
-              primaryText="Change Theme"
-              leftIcon={<ArrowDropLeft />}
-              menuItems={[
-                <MenuItem
-                  key="light"
-                  primaryText="Light Theme"
-                  onClick={() => { changeLight() }} />,
-                <MenuItem
-                  key="dark"
-                  primaryText="Dark Theme"
-                  onClick={() => {changeDark() }} />,
-                 <MenuItem primaryText="Custom Theme"
-                 key="custom"
-                  onClick={this.handleThemeChanger} />
-                ]}
-              />
         </IconMenu>)
       return <Logged />
     }
@@ -213,28 +212,13 @@ class MessageSection extends Component {
         targetOrigin={{ horizontal: 'right', vertical: 'top' }}
         anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
       >
+        <MenuItem primaryText="Settings"
+          onClick={this.handleSettings} />
+        <MenuItem primaryText="Connect to SUSI Hardware"
+          onClick={this.handleHardware} />
         <MenuItem primaryText="Login" onTouchTap={this.handleOpen} />
         <MenuItem primaryText="Sign Up"
           containerElement={<Link to="/signup" />} />
-        <MenuItem primaryText="Connect to SUSI Hardware"
-            onClick={this.handleHardware} />
-        <MenuItem
-          primaryText="Change Theme"
-          leftIcon={<ArrowDropLeft />}
-          menuItems={[
-            <MenuItem
-              key="light"
-              primaryText="Light Theme"
-              onClick={() => { changeLight() }} />,
-            <MenuItem
-              key="dark"
-              primaryText="Dark Theme"
-              onClick={() => {changeDark() }} />,
-            <MenuItem primaryText="Custom Theme"
-            key="custom"
-              onClick={this.handleThemeChanger} />
-            ]}
-          />
       </IconMenu>)
 
     return <Logged />
@@ -244,18 +228,6 @@ class MessageSection extends Component {
     MessageStore.removeChangeListener(this._onChange.bind(this));
     ThreadStore.removeChangeListener(this._onChange.bind(this));
     SettingStore.removeChangeListener(this._onChange.bind(this));
-  }
-
-  themeChangerLight(event) {
-    if(!this.state.darkTheme){
-      Actions.themeChanged(!this.state.darkTheme);
-    }
-  }
-
-  themeChangerDark(event) {
-    if(this.state.darkTheme){
-      Actions.themeChanged(!this.state.darkTheme);
-    }
   }
 
   componentWillMount() {
@@ -269,15 +241,22 @@ class MessageSection extends Component {
       }
     }
 
-    SettingStore.on('change', () => {
+    UserPreferencesStore.on('change', () => {
       this.setState({
-        darkTheme: SettingStore.getTheme()
+        currTheme: UserPreferencesStore.getTheme()
       })
-      if (!this.state.darkTheme) {
-        document.body.className = 'white-body';
-      }
-      else {
-        document.body.className = 'dark-body';
+      switch(this.state.currTheme){
+        case 'light':{
+          document.body.className = 'white-body';
+          break;
+        }
+        case 'dark':{
+          document.body.className = 'dark-body';
+          break;
+        }
+        default: {
+            // do nothing
+        }
       }
     })
   }
@@ -292,24 +271,31 @@ class MessageSection extends Component {
       dream
     } = this.props;
     var backgroundCol;
-    let topBackground = this.state.darkTheme ? '' : 'dark';
-
-    if (topBackground === 'dark') {
-      backgroundCol =  '#19324c';
+    let topBackground = this.state.currTheme;
+    switch(topBackground){
+      case 'light':{
+        backgroundCol = '#607d8b';
+        break;
+      }
+      case 'dark':{
+        backgroundCol =  '#19324c';
+        break;
+      }
+      default: {
+          // do nothing
+      }
     }
-    else {
-      backgroundCol = '#607d8b';
 
-    }
     const actions = <RaisedButton
       label="Cancel"
       backgroundColor={
-        SettingStore.getTheme() ? '#607D8B' : '#19314B'}
+        UserPreferencesStore.getTheme()==='light' ? '#607D8B' : '#19314B'}
       labelColor="#fff"
       width='200px'
       keyboardFocused={true}
       onTouchTap={this.handleClose}
     />;
+
     const componentsList = [
       {'id':1, 'component':'header', 'name': 'Header'},
       {'id':2, 'component': 'pane', 'name': 'Message Pane'},
@@ -370,14 +356,13 @@ class MessageSection extends Component {
                 <div className='compose' style={{background:composer}}>
                   <MessageComposer
                     threadID={this.state.thread.id}
-                    theme={this.state.darkTheme}
                     dream={dream}
                     textarea={this.state.textarea} />
                 </div>
               </div>
             </div>
             <Dialog
-            className='dialogStyle'
+              className='dialogStyle'
               actions={actions}
               modal={false}
               open={this.state.open}
@@ -395,7 +380,8 @@ class MessageSection extends Component {
               bodyStyle={bodyStyle}
               onRequestClose={this.handleClose}>
               <div>
-                <Settings {...this.props} />
+                <Settings {...this.props}
+                  onSettingsSubmit={this.implementSettings} />
               </div>
             </Dialog>
             <Dialog
@@ -406,7 +392,7 @@ class MessageSection extends Component {
               bodyStyle={bodyStyle}
               onRequestClose={this.handleClose}>
               <div>
-                <HardwareComponent {...this.props}/>
+                <HardwareComponent {...this.props} />
               </div>
             </Dialog>
             <Dialog
@@ -427,7 +413,7 @@ class MessageSection extends Component {
       if (this.state.search) {
         return (
           <SearchSection messages={this.state.messages}
-            theme={this.state.darkTheme}
+            theme={this.state.currTheme}
           />
         );
       }
@@ -437,11 +423,18 @@ class MessageSection extends Component {
   }
 
   componentDidUpdate() {
-    if (this.state.darkTheme) {
-      document.body.className = 'white-body';
-    }
-    else {
-      document.body.className = 'dark-body';
+    switch(this.state.currTheme){
+      case 'light':{
+        document.body.className = 'white-body';
+        break;
+      }
+      case 'dark':{
+        document.body.className = 'dark-body';
+        break;
+      }
+      default: {
+          // do nothing
+      }
     }
     this._scrollToBottom();
   }
@@ -465,15 +458,6 @@ class MessageSection extends Component {
   }
 
 };
-function changeLight() {
-  let messageSection = new MessageSection();
-  messageSection.themeChangerLight();
-}
-function changeDark() {
-  let messageSection = new MessageSection();
-  messageSection.themeChangerDark();
-}
-
 
 Logged.muiName = 'IconMenu';
 

--- a/src/components/ChatApp/SearchSection.react.js
+++ b/src/components/ChatApp/SearchSection.react.js
@@ -13,6 +13,7 @@ import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import IconButton from 'material-ui/IconButton';
 import Popover from 'material-ui/Popover';
 import Toggle from 'material-ui/Toggle';
+import UserPreferencesStore from '../../stores/UserPreferencesStore';
 
 function getMessageListItem(messages, markID) {
   return messages.map((message) => {
@@ -69,7 +70,8 @@ class SearchSection extends Component {
       scrollID: null,
       caseSensitive: false,
       open: false,
-      searchText: ''
+      searchText:'',
+      currTheme: UserPreferencesStore.getTheme(),
     };
     this.handleOptions = this.handleOptions.bind(this);
     this.handleRequestClose = this.handleRequestClose.bind(this);
@@ -81,11 +83,18 @@ class SearchSection extends Component {
   }
 
   componentWillMount() {
-    if (this.props.theme) {
-      document.body.className = 'white-body';
-    }
-    else {
-      document.body.className = 'dark-body';
+    switch(this.state.currTheme){
+      case 'light':{
+        document.body.className = 'white-body';
+        break;
+      }
+      case 'dark':{
+        document.body.className = 'dark-body';
+        break;
+      }
+      default: {
+          // do nothing
+      }
     }
   }
 
@@ -102,15 +111,21 @@ class SearchSection extends Component {
     let markID = this.state.scrollID;
     let markedMessages = this.state.markedMsgs;
     let messageListItems = getMessageListItem(
-      markedMessages, markID);
-    let topBackground = this.props.theme ? '' : 'dark';
+                                  markedMessages,markID);
+    let topBackground = this.state.currTheme;
     var backgroundCol;
-    if (topBackground === 'dark') {
-      backgroundCol = '#19324c';
-    }
-    else {
-      backgroundCol = '#607d8b';
-
+    switch(topBackground){
+      case 'light':{
+        backgroundCol = '#607d8b';
+        break;
+      }
+      case 'dark':{
+        backgroundCol =  '#19324c';
+        break;
+      }
+      default: {
+          // do nothing
+      }
     }
 
     const searchField = (
@@ -321,7 +336,6 @@ class SearchSection extends Component {
 
 SearchSection.propTypes = {
   messages: PropTypes.array,
-  theme: PropTypes.bool
 };
 
 export default SearchSection;

--- a/src/components/ChatApp/Settings.react.js
+++ b/src/components/ChatApp/Settings.react.js
@@ -3,8 +3,6 @@ import Paper from 'material-ui/Paper';
 import RaisedButton from 'material-ui/RaisedButton';
 import DropDownMenu from 'material-ui/DropDownMenu';
 import MenuItem from 'material-ui/MenuItem';
-import SettingStore from '../../stores/SettingStore';
-import * as Actions from '../../actions/';
 import PropTypes from 'prop-types';
 import TextField from 'material-ui/TextField';
 import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
@@ -25,31 +23,28 @@ class Settings extends Component {
             checked: false,
 			validForm: true
 		};
-		this.handleSubmit = this.handleSubmit.bind(this);
-		this.handleChange = this.handleChange.bind(this);
-		this.handleSelectChange = this.handleSelectChange.bind(this);
+
 		this.customServerMessage = '';
 	}
 
-	handleSubmit(e){
-		e.preventDefault();
-		let newDefaultTheme = this.state.theme;
+	handleSubmit = () => {
+		let newTheme = this.state.theme;
 		let newDefaultServer = this.state.server;
 		if(newDefaultServer.slice(-1)==='/'){
 			newDefaultServer = newDefaultServer.slice(0,-1);
 		}
-		console.log(newDefaultServer);
-		Actions.setDefaultTheme(newDefaultTheme);
-		Actions.setDefaultServer(newDefaultServer);
-		this.props.history.push('/');
-		window.location.reload();
+		let vals = {
+			theme: newTheme,
+			server: newDefaultServer
+		}
+		this.props.onSettingsSubmit(vals);
 	}
 
-	handleSelectChange(event, index, value){
+	handleSelectChange= (event, index, value) => {
 		this.setState({theme:value});
 	}
 
-	handleChange(event) {
+	handleChange = (event) => {
         let state = this.state;
         let serverUrl;
         if (event.target.value === 'customServer') {
@@ -73,8 +68,7 @@ class Settings extends Component {
         }
 
         if (state.serverFieldError) {
-        	this.customServerMessage
-        	= 'Enter a valid URL';
+        	this.customServerMessage = 'Enter a valid URL';
         }
         else{
         	this.customServerMessage = '';
@@ -107,70 +101,70 @@ class Settings extends Component {
 		};
 
 		const serverURL = <TextField name="serverUrl"
-									onChange={this.handleChange}
-									errorText={this.customServerMessage}
-									floatingLabelText="Custom URL" />;
+							onChange={this.handleChange}
+							errorText={this.customServerMessage}
+							floatingLabelText="Custom URL" />;
 		const hidden = this.state.checked ? serverURL : '';
 
 		return (
 			<div className="loginForm">
 				<Paper zDepth={0} style={styles}>
 					<h1>Settings</h1>
-					<form onSubmit={this.handleSubmit}>
 					<div>
-					<h4>Default Theme:</h4>
-					<DropDownMenu
-						label='Default Theme'
-						value={this.state.theme}
-						onChange={this.handleSelectChange}>
-			          <MenuItem value={'light'} primaryText="Light" />
-			          <MenuItem value={'dark'} primaryText="Dark" />
-			        </DropDownMenu>
+						<h4>Theme:</h4>
+						<DropDownMenu
+							label='Default Theme'
+							value={this.state.theme}
+							onChange={this.handleSelectChange}>
+				          <MenuItem value={'light'} primaryText="Light" />
+				          <MenuItem value={'dark'} primaryText="Dark" />
+				        </DropDownMenu>
 			        </div>
 					<div>
-					<h4>Default Server:</h4>
-					<RadioButtonGroup style={{display: 'flex',
-					  marginTop: '10px',
-					  maxWidth:'200px',
-					  flexWrap: 'wrap',
-					margin: 'auto'}}
-					 name="server" onChange={this.handleChange}
-					 defaultSelected="standardServer">
-					<RadioButton
-					       value="customServer"
-					       label="Custom Server"
-					       labelPosition="left"
-					       style={radioButtonStyles.radioButton}
-					     />
-					<RadioButton
-					       value="standardServer"
-					       label="Standard Server"
-					       labelPosition="left"
-					       style={radioButtonStyles.radioButton}
-					     />
-					</RadioButtonGroup>
+						<h4>Server:</h4>
+						<RadioButtonGroup style={{display: 'flex',
+						  marginTop: '10px',
+						  maxWidth:'200px',
+						  flexWrap: 'wrap',
+						  margin: 'auto'}}
+						 name="server" onChange={this.handleChange}
+						 defaultSelected="standardServer">
+						<RadioButton
+						       value="customServer"
+						       label="Custom Server"
+						       labelPosition="left"
+						       style={radioButtonStyles.radioButton}
+						     />
+						<RadioButton
+						       value="standardServer"
+						       label="Standard Server"
+						       labelPosition="left"
+						       style={radioButtonStyles.radioButton}
+						     />
+						</RadioButtonGroup>
 					</div>
 					<div>
-					{hidden}
+						{hidden}
 					</div>
 					<div>
 						<RaisedButton
-							label="Set Defaults"
-							type="submit"
+							label="Save"
 							disabled={!this.state.validForm}
 							backgroundColor={
-								SettingStore.getTheme() ? '#607D8B' : '#19314B'}
+								UserPreferencesStore.getTheme()==='light'
+								? '#607D8B' : '#19314B'}
 							labelColor="#fff"
+							onClick={this.handleSubmit}
 						/>
 					</div>
-					</form>
 				</Paper>
 			</div>);
 	}
 }
 
 Settings.propTypes = {
-	history: PropTypes.object
+	history: PropTypes.object,
+	onSettingsSubmit: PropTypes.func
 };
 
 export default Settings;

--- a/src/stores/SettingStore.js
+++ b/src/stores/SettingStore.js
@@ -6,7 +6,6 @@ let ActionTypes = ChatConstants.ActionTypes;
 let CHANGE_EVENT = 'change';
 
 let _searchMode = false;
-let _theme = true;
 
 let SettingStore = {
     ...EventEmitter.prototype,
@@ -17,10 +16,6 @@ let SettingStore = {
 
     getSearchMode() {
         return _searchMode;
-    },
-
-    getTheme() {
-        return _theme;
     },
 
     addChangeListener(callback) {
@@ -38,29 +33,6 @@ SettingStore.dispatchToken = ChatAppDispatcher.register(action => {
     switch (action.type) {
         case ActionTypes.SEARCH_MODE: {
             _searchMode = !_searchMode;
-            SettingStore.emitChange();
-            break;
-        }
-        case ActionTypes.THEME_CHANGED: {
-            _theme = !_theme;
-            SettingStore.emitChange();
-            break;
-        }
-        case ActionTypes.SET_DEFAULT_THEME: {
-            let defaultTheme = action.theme;
-            switch (defaultTheme) {
-                case 'light': {
-                    _theme = true;
-                    break;
-                }
-                case 'dark': {
-                    _theme = false;
-                    break;
-                }
-                default: {
-                    // do nothing
-                }
-            }
             SettingStore.emitChange();
             break;
         }

--- a/src/stores/UserPreferencesStore.js
+++ b/src/stores/UserPreferencesStore.js
@@ -22,6 +22,10 @@ let UserPreferencesStore = {
         return _defaults;
     },
 
+    getTheme(){
+        return _defaults.Theme;
+    },
+
     addChangeListener(callback) {
         this.on(CHANGE_EVENT, callback);
     },
@@ -36,9 +40,8 @@ UserPreferencesStore.dispatchToken = ChatAppDispatcher.register(action => {
 
     switch (action.type) {
 
-        case ActionTypes.DEFAULT_THEME_CHANGED: {
-            let newDefaultTheme = action.defaultTheme;
-            _defaults.Theme = newDefaultTheme;
+        case ActionTypes.THEME_CHANGED: {
+            _defaults.Theme = action.theme;
             console.log(_defaults);
             UserPreferencesStore.emitChange();
             break;


### PR DESCRIPTION
Fixes issue #295 

**Changes:**
* Removed theme from SettingsStore and all the actions related to it
* Used theme in UserPreferencesStore to store theme upon every theme change action

**Needs to be implemented:**
* Pushing and pulling the user data (UserPreferencesStore data) to and from server so that the changes  are maintained upon refreshing the page or login logout.

**Demo Link:**  http://changethemesetting.surge.sh/

**Screenshots:**

![settings](https://user-images.githubusercontent.com/13276887/27299900-79687b78-554b-11e7-8b43-abe2c14722d1.png)
 
