### PR TITLE
Fixes #307 - Handle All types Of HTML Special Entities Parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "classnames": "^2.2.5",
     "flux": "^3.1.2",
     "history": "^4.6.1",
+    "html-entities": "^1.2.1",
     "jquery": "^3.2.1",
     "keymirror": "^0.1.1",
     "leaflet": "^1.0.3",

--- a/src/components/ChatApp/MessageListItem.react.js
+++ b/src/components/ChatApp/MessageListItem.react.js
@@ -16,6 +16,9 @@ import { divIcon } from 'leaflet';
 import Paper from 'material-ui/Paper';
 import {Carousel} from 'react-responsive-carousel';
 import TextHighlight from 'react-text-highlight';
+import {AllHtmlEntities} from 'html-entities';
+
+const entities = new AllHtmlEntities();
 
 // Linkify the text
 export function parseAndReplace(text) {
@@ -24,26 +27,10 @@ export function parseAndReplace(text) {
   </Linkify>;
 }
 
-// Decode HTML Spl Chars
-function parseHTMLSplChars(text) {
-  if(text){
-    let map = {
-      '&amp;': '&',
-      '&lt;': '<',
-      '&gt;': '>',
-      '&quot;': '"',
-      '&#039;': "'"
-    };
-    return text.replace(/&amp;|&lt;|&gt;|&quot;|&#039;/g,
-                      function(splChar) {return map[splChar];});
-  }
-  return text;
-}
-
 // Proccess the text for HTML Spl Chars, Images, Links and Emojis
 function processText(text){
   if(text){
-    let htmlText = parseHTMLSplChars(text);
+    let htmlText = entities.decode(text);
     let imgText = imageParse(htmlText);
     let replacedText = parseAndReplace(imgText);
     return <Emojify>{replacedText}</Emojify>;
@@ -268,7 +255,7 @@ class MessageListItem extends React.Component {
       let matchString = this.props.message.mark.matchText;
       let isCaseSensitive = this.props.message.mark.isCaseSensitive;
       if(stringWithLinks){
-        let htmlText = parseHTMLSplChars(stringWithLinks);
+        let htmlText = entities.decode(stringWithLinks);
         let imgText = imageParse(htmlText);
         let markedText = [];
         let matchStringarr = [];


### PR DESCRIPTION
Fixes issue #307 

**Changes:**
* Added a module to parse all kinds of html special chars and entities

**Demo Link:** http://htmlsplchars.surge.sh/

**Etherpad Link:** http://dream.susi.ai/p/splhtmlchars

**Screenshot:** 

![html](https://user-images.githubusercontent.com/13276887/27373677-db955a46-5686-11e7-81e7-18597d90c433.png)


