### PR TITLE
Fixes:#310 search allows spaces

### DIFF
--- a/src/components/ChatApp/SearchSection.react.js
+++ b/src/components/ChatApp/SearchSection.react.js
@@ -302,7 +302,7 @@ class SearchSection extends Component {
   }
 
   _searchMsg(e) {
-    let matchString = e.target.value.trim();
+    let matchString = e.target.value;
     let messages = this.props.messages;
     let markingData = searchMsgs(messages, matchString, this.state.caseSensitive);
     if (matchString) {


### PR DESCRIPTION
Fixes issue #310 
Changes: 
- now it does not trim the search keyword.
- it gives users to search for words and word phases.

Demo Link: http://isuruab1.surge.sh/

Screenshots for the change: 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/7692626/27377129-b8593100-5691-11e7-8bf1-617385b9bee6.gif)

