### PR TITLE
Fixes #323 - Remove the anchor styling for tile text

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -381,8 +381,9 @@ textarea {
 
 .tile{
   width: 100%;
-  padding-left: 10px;
-  padding-right: 5px;
+  height: 100px;
+  padding-left: 7%;
+  padding-right: 2%;
 }
 .slick-slide{
   margin: 0 10px;
@@ -409,7 +410,6 @@ textarea {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  line-height: 200%;
 }
 
 .tile-title{
@@ -435,11 +435,7 @@ textarea {
 }
 
 .tile-anchor{
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: block;
-  float: right;
+  text-decoration: none;
 }
 
 a {

--- a/src/components/ChatApp/MessageListItem.react.js
+++ b/src/components/ChatApp/MessageListItem.react.js
@@ -28,12 +28,23 @@ export function parseAndReplace(text) {
 }
 
 // Proccess the text for HTML Spl Chars, Images, Links and Emojis
-function processText(text){
+function processText(text,type){
   if(text){
-    let htmlText = entities.decode(text);
-    let imgText = imageParse(htmlText);
-    let replacedText = parseAndReplace(imgText);
-    return <Emojify>{replacedText}</Emojify>;
+  	let processedText = '';
+  	switch(type){
+  		case 'websearch-rss':{
+  			let htmlText = entities.decode(text);
+		    processedText = <Emojify>{htmlText}</Emojify>;
+  			break;
+  		}
+  		default:{
+  			let htmlText = entities.decode(text);
+		    let imgText = imageParse(htmlText);
+		    let replacedText = parseAndReplace(imgText);
+		    processedText = <Emojify>{replacedText}</Emojify>;
+  		}
+  	}
+  	return processedText;
   };
   return text;
 }
@@ -70,20 +81,24 @@ function drawTiles(tilesData){
         <div key={i}>
           <MuiThemeProvider>
             <Paper zDepth={0} className='tile'>
-              <a rel='noopener noreferrer' href={tile.link} target='_blank'>
-              {tile.icon &&
-                (<div className='tile-img-container'>
-                  <img src={tile.icon}
-                  className='tile-img' alt=''/>
-                  </div>
-                )}
-              <div className='tile-text'>
-                <p className='tile-title'>
-                  <strong>{processText(tile.title)}</strong>
-                </p>
-                {processText(tile.description)}<br/>
-              </div>
-              </a>
+            	<a rel='noopener noreferrer'
+              	href={tile.link} target='_blank'
+              	className='tile-anchor'>
+              		{tile.icon &&
+	                (<div className='tile-img-container'>
+	                  	<img src={tile.icon}
+	                  	className='tile-img' alt=''/>
+	                  </div>
+	                )}
+	                <div className='tile-text'>
+	                	<p className='tile-title'>
+	                		<strong>
+	                  			{processText(tile.title,'websearch-rss')}
+	                  		</strong>
+	                  	</p>
+	                	{processText(tile.description,'websearch-rss')}
+	              	</div>
+              	</a>
             </Paper>
           </MuiThemeProvider>
         </div>
@@ -109,7 +124,7 @@ function renderTiles(tiles){
       };
   return(
     <Slider {...settings}>
-           {resultTiles}
+    	{resultTiles}
     </Slider>
   );
 }


### PR DESCRIPTION
Fixes issue #323 

**Changes:**
* Removed the anchor tag styling for tile text - the tile content wont show any underline but the entire tile is hyperlinked.

**Demo Link:**  http://websearchrss.surge.sh/

**Screenshots for the change:** 

![tile](https://user-images.githubusercontent.com/13276887/27505915-cc2f1296-58c9-11e7-89ee-5bd7695c52fa.png)

