### PR TITLE
Fixes #337 - Fix settings dialog content alignment in mobile screens

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -444,9 +444,11 @@ a {
   text-overflow: ellipsis;
   display: block;
 }
+
 .dark a{
   color: #80a9a5;
 }
+
 .theme-button{
   line-height: 52px;
   background: #19324c;
@@ -456,6 +458,7 @@ a {
   font-size: 13px;
   cursor: pointer;
 }
+
 .dark .theme-button{
   line-height: 52px;
   background: #607d8b;
@@ -463,9 +466,11 @@ a {
   padding: 0 10px;
   color:#fff;
 }
+
 .dialogStyle div{
     margin: 0 auto;
 }
+
 em{
   background-color: orange;
 }
@@ -479,7 +484,16 @@ em{
   margin: 0 auto;
 }
 
-@media screen and (max-width: 768px) {
+.settingsDialog {
+  text-align: left;
+  padding-left: 25%;
+}
+
+.settingsBtns {
+  margin-bottom: 16px;
+}
+
+@media only screen and (min-width: 0px) and (max-width: 768px){
   .settingsForm {
     font-size: 14px;
   }
@@ -491,5 +505,14 @@ em{
   }
   .settingsForm h4{
     font-size: 14px;
+  }
+  .settingsDialog {
+    text-align: left;
+    padding-left: 10%;
+    line-height: 80%;
+  }
+  .settingsBtns{
+    margin-bottom: 16px;
+    width: 85%;
   }
 }

--- a/src/components/ChatApp/Settings.react.js
+++ b/src/components/ChatApp/Settings.react.js
@@ -97,11 +97,6 @@ class Settings extends Component {
 
 	render() {
 
-		const styles = {
-			'textAlign': 'left',
-			'paddingLeft': '25%'
-		}
-
 		const Buttonstyles = {
 			marginBottom: 16,
 		}
@@ -130,7 +125,7 @@ class Settings extends Component {
 			<div className="settingsForm">
 				<Paper zDepth={0}>
 					<h1>Chat Settings</h1>
-					<div style={styles}>
+					<div className='settingsDialog'>
 					<div>
 						<h4 style={subHeaderStyle}>Select Theme:</h4>
 						<DropDownMenu
@@ -144,10 +139,11 @@ class Settings extends Component {
 			        {cookies.get('loggedIn') ?
 			        <div>
 			        <h4 style={subHeaderStyle}>Server Settings:</h4>
-								<FlatButton
-									style={Buttonstyles}
-									label="Select backend server for the app"
-									onClick={this.handleServer} />
+						<FlatButton
+							className='settingsBtns'
+							style={Buttonstyles}
+							label="Select backend server for the app"
+							onClick={this.handleServer} />
 
 			    	</div>
 			       	:
@@ -175,10 +171,11 @@ class Settings extends Component {
 					}
 			    	<div>
 			    	<h4 style={subHeaderStyle}>Connect to SUSI Hardware:</h4>
-							<FlatButton
-								style={Buttonstyles}
-								label="Add address to connect to Hardware"
-								onClick={this.handleHardware} />
+						<FlatButton
+							className='settingsBtns'
+							style={Buttonstyles}
+							label="Add address to connect to Hardware"
+							onClick={this.handleHardware} />
 			    	</div>
 			    	</div>
 			    	<div>


### PR DESCRIPTION
Fixes issue #337 

**Changes:**
* Styled settings dialog for mobile screens
* Fixed the padding - making it closer to the left of the dialog

**Demo Link:** http://mobilesettings.surge.sh/

**Screenshots for the change:** 

![mobset](https://user-images.githubusercontent.com/13276887/27573721-d0edd6f0-5b30-11e7-87c6-8e4d66c574cb.png)


