### PR TITLE
Fixes #376 - Remove warning for missing initialised prop in dialog section

### DIFF
--- a/src/components/ChatApp/MessageSection/DialogSection.js
+++ b/src/components/ChatApp/MessageSection/DialogSection.js
@@ -40,7 +40,8 @@ export default class DialogSection extends Component {
           bodyStyle={this.props.bodyStyle}
           contentStyle={{width: '35%',minWidth: '300px'}}
           onRequestClose={this.props.onRequestClose()}>
-          <Login {...this.props} />
+          <Login {...this.props}
+            showForgotPassword={this.showForgotPassword}/>
         </Dialog>
 
       {/* Forgot Password */}

--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -22,7 +22,8 @@ function getStateFromStores() {
     currTheme: UserPreferencesStore.getTheme(),
     search: false,
     showLoading: MessageStore.getLoadStatus(),
-    open: false,
+    showLogin: false,
+    showSignUp: false,
     showForgotPassword: false,
     showSettings: false,
     showThemeChanger: false,
@@ -130,7 +131,7 @@ class MessageSection extends Component {
   };
 
   state = {
-    open: false
+    showLogin: false
   };
 
   constructor(props) {
@@ -167,7 +168,9 @@ class MessageSection extends Component {
   }
 
   handleOpen = () => {
-    this.setState({ open: true });
+    this.setState({
+      showLogin: true
+    });
   }
   handleSignUp = () => {
     this.setState({
@@ -177,7 +180,7 @@ class MessageSection extends Component {
 
   handleClose = () => {
     this.setState({
-      open: false,
+      showLogin: false,
       showSignUp: false,
       showSettings: false,
       showThemeChanger: false,
@@ -205,13 +208,13 @@ class MessageSection extends Component {
     if(toShow){
       this.setState({
         showForgotPassword: true,
-        open: false,
+        showLogin: false,
       });
     }
     else{
       this.setState({
         showForgotPassword: false,
-        open: true,
+        showLogin: true,
       });
     }
   }
@@ -262,7 +265,7 @@ class MessageSection extends Component {
       // Logout the user and show the login screen again
       this.props.history.push('/logout');
       this.setState({
-        open:true
+        showLogin:true
       });
     }
     else{
@@ -337,7 +340,7 @@ class MessageSection extends Component {
       if (this.props.location.state) {
         if (this.props.location.state.hasOwnProperty('showLogin')) {
           let showLogin = this.props.location.state.showLogin;
-          this.setState({ open: showLogin });
+          this.setState({ showLogin: showLogin });
         }
       }
     }
@@ -519,7 +522,7 @@ class MessageSection extends Component {
 
             <DialogSection
               {...this.props}
-              openLogin={this.state.open}
+              openLogin={this.state.showLogin}
               openForgotPassword={this.state.showForgotPassword}
               openSetting={this.state.showSettings}
               openSignUp={this.state.showSignUp}


### PR DESCRIPTION
Fixes issue #376 

**Changes:**
* Initialised `showSignUp` in state as `false`
* Changed `open` into `showLogin` to maintain code readability
* Addded missing `showForgotPassword` prop to `Login` in Dialog Section

**Demo Link:** http://dialogwarnfix.surge.sh/


@rishiraj824 @isuruAb @madhavrathi please review
