### PR TITLE
Fixes #382 - Added status indicators to user messages

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -249,6 +249,7 @@ header{
 }
 
 .message-time, .thread-time {
+  list-style-type: none;
   font-size: 12px;
   color: #90a4ae;
   margin: 0;

--- a/src/components/ChatApp/MessageListItem/MessageListItem.react.js
+++ b/src/components/ChatApp/MessageListItem/MessageListItem.react.js
@@ -5,15 +5,20 @@ import TextHighlight from 'react-text-highlight';
 import {AllHtmlEntities} from 'html-entities';
 import $ from 'jquery';
 import { imageParse, processText,
-  renderTiles, drawMap,
-  drawTable, getRSSTiles } from './helperFunctions.react.js';
-const entities = new AllHtmlEntities();
+  renderTiles, drawMap, drawTable,
+  getRSSTiles, renderMessageFooter } from './helperFunctions.react.js';
 
+const entities = new AllHtmlEntities();
 
 class MessageListItem extends React.Component {
 
   render() {
     let {message} = this.props;
+
+    let latestUserMsgID = null;
+    if(this.props.latestUserMsgID){
+      latestUserMsgID = this.props.latestUserMsgID;
+    }
 
     if(this.props.message.type === 'date'){
       return(
@@ -89,12 +94,7 @@ class MessageListItem extends React.Component {
                 <li className='message-list-item' key={action+index}>
                   <section  className={messageContainerClasses}>
                   <div className='message-text'>{replacedText}</div>
-                  <div className='message-time'>
-                    {message.date.toLocaleString(
-                      'en-US',
-                      { hour: 'numeric',minute:'numeric', hour12: true }
-                    )}
-                  </div>
+                    {renderMessageFooter(message,latestUserMsgID)}
                   </section>
                 </li>
               );
@@ -110,12 +110,7 @@ class MessageListItem extends React.Component {
                     <a href={link} target='_blank'
                       rel='noopener noreferrer'>{text}</a>
                   </div>
-                  <div className='message-time'>
-                    {message.date.toLocaleString(
-                      'en-US',
-                      { hour: 'numeric',minute:'numeric', hour12: true }
-                    )}
-                  </div>
+                    {renderMessageFooter(message,latestUserMsgID)}
                   </section>
                 </li>
               );
@@ -138,12 +133,7 @@ class MessageListItem extends React.Component {
                       <li className='message-list-item' key={action+index}>
                         <section className={messageContainerClasses}>
                         <div>{mymap}</div>
-                        <div className='message-time'>
-                          {message.date.toLocaleString(
-                            'en-US',
-                            { hour: 'numeric',minute:'numeric', hour12: true }
-                          )}
-                        </div>
+                          {renderMessageFooter(message,latestUserMsgID)}
                         </section>
                       </li>
                       );
@@ -160,12 +150,7 @@ class MessageListItem extends React.Component {
                 <li className='message-list-item' key={action+index}>
                   <section className={messageContainerClasses}>
                   <div>{mymap}</div>
-                  <div className='message-time'>
-                    {message.date.toLocaleString(
-                      'en-US',
-                      { hour: 'numeric',minute:'numeric', hour12: true }
-                    )}
-                  </div>
+                    {renderMessageFooter(message,latestUserMsgID)}
                   </section>
                 </li>
                 );
@@ -179,12 +164,7 @@ class MessageListItem extends React.Component {
                 <li className='message-list-item' key={action+index}>
                   <section className={messageContainerClasses}>
                   <div><div className='message-text'>{table}</div></div>
-                  <div className='message-time'>
-                    {message.date.toLocaleString(
-                      'en-US',
-                      { hour: 'numeric',minute:'numeric', hour12: true }
-                    )}
-                  </div>
+                    {renderMessageFooter(message,latestUserMsgID)}
                   </section>
                 </li>
               );
@@ -205,12 +185,7 @@ class MessageListItem extends React.Component {
                     <div><div className='message-text'>
                       {renderTiles(rssTiles)}
                     </div></div>
-                    <div className='message-time'>
-                      {message.date.toLocaleString(
-                        'en-US',
-                        { hour: 'numeric',minute:'numeric', hour12: true }
-                      )}
-                    </div>
+                      {renderMessageFooter(message,latestUserMsgID)}
                     </section>
                   </li>
                 );
@@ -224,12 +199,7 @@ class MessageListItem extends React.Component {
                     <div><div className='message-text'>
                       {renderTiles(websearchTiles)}
                     </div></div>
-                    <div className='message-time'>
-                      {message.date.toLocaleString(
-                        'en-US',
-                        { hour: 'numeric',minute:'numeric', hour12: true }
-                      )}
-                    </div>
+                      {renderMessageFooter(message,latestUserMsgID)}
                     </section>
                   </li>
                 );
@@ -249,12 +219,7 @@ class MessageListItem extends React.Component {
       <li className='message-list-item'>
         <section  className={messageContainerClasses}>
         <div className='message-text'>{replacedText}</div>
-        <div className='message-time'>
-          {message.date.toLocaleString(
-            'en-US',
-            { hour: 'numeric',minute:'numeric', hour12: true }
-          )}
-        </div>
+          {renderMessageFooter(message,latestUserMsgID)}
         </section>
       </li>
     );
@@ -264,7 +229,8 @@ class MessageListItem extends React.Component {
 
 MessageListItem.propTypes = {
   message: PropTypes.object,
-  markID: PropTypes.string
+  markID: PropTypes.string,
+  latestUserMsgID: PropTypes.string,
 };
 
 export default MessageListItem;

--- a/src/components/ChatApp/MessageListItem/helperFunctions.react.js
+++ b/src/components/ChatApp/MessageListItem/helperFunctions.react.js
@@ -15,6 +15,10 @@ import { divIcon } from 'leaflet';
 import Paper from 'material-ui/Paper';
 import Slider from 'react-slick';
 import {AllHtmlEntities} from 'html-entities';
+import TickIcon from 'material-ui/svg-icons/action/done';
+import ClockIcon from 'material-ui/svg-icons/action/schedule';
+import UserPreferencesStore from '../../../stores/UserPreferencesStore';
+
 const entities = new AllHtmlEntities();
 
 // Keeps the Map Popup open initially
@@ -27,6 +31,50 @@ class ExtendedMarker extends Marker {
   }
 }
 
+// Returns the message time and status indicator
+export function renderMessageFooter(message,latestMsgID){
+
+  let statusIndicator = null;
+
+  let footerStyle = {
+    display: 'block',
+    float: 'left'
+  }
+
+  if(message.authorName === 'You'){
+    let indicatorStyle = {
+      height:'13px'
+    }
+    statusIndicator = (
+      <li className='message-time' style={footerStyle}>
+        <TickIcon style={indicatorStyle}
+          color={UserPreferencesStore.getTheme()==='light' ? '#90a4ae' : '#7eaaaf'}/>
+      </li>);
+    if(message.id === latestMsgID){
+      statusIndicator = (
+        <li className='message-time' style={footerStyle}>
+          <ClockIcon style={indicatorStyle}
+            color={UserPreferencesStore.getTheme()==='light' ? '#90a4ae' : '#7eaaaf'}/>
+        </li>);
+    }
+  }
+
+  if(message.authorName === 'SUSI'){
+    footerStyle = {};
+  }
+
+  return(
+    <ul>
+      <li className='message-time' style={footerStyle}>
+        {message.date.toLocaleString(
+          'en-US',
+          { hour: 'numeric',minute:'numeric', hour12: true }
+        )}
+      </li>
+      {statusIndicator}
+    </ul>
+  );
+}
 
 // Proccess the text for HTML Spl Chars, Images, Links and Emojis
 export function processText(text,type){

--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -48,7 +48,8 @@ function getStateFromStores() {
   };
 }
 
-function getMessageListItem(messages, markID) {
+function getMessageListItem(messages, showLoading, markID) {
+  // markID indicates search mode on
   if(markID){
     return messages.map((message) => {
       return (
@@ -60,12 +61,22 @@ function getMessageListItem(messages, markID) {
       );
     });
   }
+  // Get message ID waiting for server response
+  let latestUserMsgID = null;
+  if(showLoading && messages){
+    let msgCount = messages.length;
+    if(msgCount>0){
+      let latestUserMsg = messages[msgCount-1];
+      latestUserMsgID = latestUserMsg.id;
+    }
+  }
 
   return messages.map((message) => {
     return (
       <MessageListItem
         key={message.id}
         message={message}
+        latestUserMsgID={latestUserMsgID}
       />
     );
   });
@@ -460,10 +471,10 @@ class MessageSection extends Component {
     if(this.state.search){
       let markID = this.state.searchState.scrollID;
       let markedMessages = this.state.searchState.markedMsgs;
-      messageListItems = getMessageListItem(markedMessages,markID);
+      messageListItems = getMessageListItem(markedMessages,false,markID);
     }
     else{
-      messageListItems = getMessageListItem(this.state.messages);
+      messageListItems = getMessageListItem(this.state.messages,this.state.showLoading);
     }
 
     if (this.state.thread) {


### PR DESCRIPTION
Fixes issue #382 

**Changes:**
* Added indicators for messages sent by user where
     1. Messages for which server response is already obtained, has a `tick` symbol
     2. Message just sent by user waiting for server response, has a `clock` symbol
* Created a new function `renderMessageFooter` in helperFunctions.js to render time and status indicator

**Demo Link:** http://messagestatusindicators.surge.sh/

**Screenshots for the change:**

![status](https://user-images.githubusercontent.com/13276887/27840380-0692bbd2-6116-11e7-8252-d5bfa04f351a.png)

 
