### PR TITLE
Fixes: #429- remove the scroll bar when the message bubble is too small .

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -297,6 +297,7 @@ header{
 }
 
 .message-container.SUSI>h5,.message-container.SUSI>.message-text {
+  overflow-wrap: break-word;
   padding-right: 16px;
 }
 


### PR DESCRIPTION
Fixes issue #429

Changes: Remove the Horizontal scroll bar when the message bubble is too small .

Demo Link:  http://isuruab.surge.sh/

Screenshots: 
<img width="337" alt="screen shot 2017-07-10 at 2 53 24 pm" src="https://user-images.githubusercontent.com/7692626/28011337-9c205fb6-657f-11e7-94fa-eab304e9a179.png">
