### PR TITLE
Fixes #445 - Support to convert HTML strings to React elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "classnames": "^2.2.5",
     "flux": "^3.1.2",
     "history": "^4.6.1",
-    "html-entities": "^1.2.1",
+    "html-react-parser": "^0.3.5",
     "jquery": "^3.2.1",
     "keymirror": "^0.1.1",
     "leaflet": "^1.0.3",

--- a/src/components/ChatApp/MessageListItem/helperFunctions.react.js
+++ b/src/components/ChatApp/MessageListItem/helperFunctions.react.js
@@ -14,12 +14,10 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import { divIcon } from 'leaflet';
 import Paper from 'material-ui/Paper';
 import Slider from 'react-slick';
-import {AllHtmlEntities} from 'html-entities';
 import TickIcon from 'material-ui/svg-icons/action/done';
 import ClockIcon from 'material-ui/svg-icons/action/schedule';
 import UserPreferencesStore from '../../../stores/UserPreferencesStore';
-
-const entities = new AllHtmlEntities();
+import Parser from 'html-react-parser';
 
 // Keeps the Map Popup open initially
 class ExtendedMarker extends Marker {
@@ -82,13 +80,12 @@ export function processText(text,type){
   	let processedText = '';
   	switch(type){
   		case 'websearch-rss':{
-  			let htmlText = entities.decode(text);
+  			let htmlText = Parser(text);
 		    processedText = <Emojify>{htmlText}</Emojify>;
   			break;
   		}
   		default:{
-  			let htmlText = entities.decode(text);
-		    let imgText = imageParse(htmlText);
+		    let imgText = imageParse(text);
 		    let replacedText = parseAndReplace(imgText);
 		    processedText = <Emojify>{replacedText}</Emojify>;
   		}
@@ -116,7 +113,7 @@ export function imageParse(stringWithLinks){
             style={{width:'95%',height:'auto'}} alt=''/>)
     }
     else{
-      result.push(item);
+      result.push(Parser(item));
     }
   });
   return result;


### PR DESCRIPTION
Fixes issue #445 

**Changes:**
* Added a new library [html-react-parser](https://www.npmjs.com/package/html-react-parser) to convert HTML strings into React elements and also handle Special HTML entities

**Demo Link:** http://htmlsupport.surge.sh/

**Etherpad Link** http://dream.susi.ai/p/anchortest

**Sample Queries**:
-  html demo
- html text

**Screenshots for the change:** 
![htmldem](https://user-images.githubusercontent.com/13276887/28085576-bd2d3fd8-6699-11e7-97f0-325e15571466.png)

