### PR TITLE
Fixes #469 - Added functionality to skill rating UI

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -4,6 +4,7 @@ import ChatAppDispatcher from '../dispatcher/ChatAppDispatcher';
 import * as ChatMessageUtils from '../utils/ChatMessageUtils';
 import ChatConstants from '../constants/ChatConstants';
 import UserPreferencesStore from '../stores/UserPreferencesStore';
+import MessageStore from '../stores/MessageStore';
 import * as Actions from './HardwareConnect.actions'
 import * as SettingsActions from './Settings.actions';
 
@@ -365,6 +366,33 @@ export function setSpeechOutputAlwaysSettings(newSpeechOutputAlways){
           +'key=speech_always&value='+newSpeechOutputAlways
           +'&access_token='+cookies.get('loggedIn');
 
+  console.log(url);
+  makeServerCall(url);
+}
+
+export function sendFeedback(){
+  let feedback = MessageStore.getFeedback();
+  console.log(feedback);
+  if(Object.keys(feedback).length === 0 && feedback.constructor === Object){
+    return;
+  }
+  let defaults = UserPreferencesStore.getPreferences();
+  let defaultServerURL = defaults.Server;
+  let BASE_URL = '';
+  if(cookies.get('serverUrl')===defaultServerURL||
+    cookies.get('serverUrl')===null||
+    cookies.get('serverUrl')=== undefined) {
+    BASE_URL = defaultServerURL;
+  }
+  else{
+    BASE_URL= cookies.get('serverUrl');
+  }
+  let url = BASE_URL+'/cms/rateSkill.json?'+
+            'model='+feedback.model+
+            '&group='+feedback.group+
+            '&language='+feedback.language+
+            '&skill='+feedback.skill+
+            '&rating='+feedback.rating;
   console.log(url);
   makeServerCall(url);
 }

--- a/src/actions/ChatApp.actions.js
+++ b/src/actions/ChatApp.actions.js
@@ -2,10 +2,12 @@ import ChatAppDispatcher from '../dispatcher/ChatAppDispatcher';
 import * as ChatWebAPIUtils from '../utils/ChatWebAPIUtils';
 import * as ChatMessageUtils from '../utils/ChatMessageUtils';
 import ChatConstants from '../constants/ChatConstants';
+import * as Actions from './API.actions';
 
 let ActionTypes = ChatConstants.ActionTypes;
 
 export function createMessage(text, currentThreadID, voice) {
+  Actions.sendFeedback();
   let message = ChatMessageUtils.getCreatedMessageData(text, currentThreadID, voice);
   ChatAppDispatcher.dispatch({
     type: ActionTypes.CREATE_MESSAGE,
@@ -39,5 +41,12 @@ export function receiveAll(rawMessages) {
 export function resetVoice() {
   ChatAppDispatcher.dispatch({
     type: ActionTypes.RESET_MESSAGE_VOICE,
+  });
+};
+
+export function saveFeedback(feedback) {
+  ChatAppDispatcher.dispatch({
+    type: ActionTypes.FEEDBACK_RECEIVED,
+    feedback
   });
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -6,6 +6,7 @@ import {  getLocation,
           setEnterAsSendSettings,
           setSpeechOutputSettings,
           setSpeechOutputAlwaysSettings,
+          sendFeedback,
           createSUSIMessage } from './API.actions';
 
 import {  getHistory } from './History.actions';
@@ -14,6 +15,7 @@ import {  createMessage,
           receiveCreatedMessage,
           clickThread,
           resetVoice,
+          saveFeedback,
           receiveAll } from './ChatApp.actions';
 
 import {  serverChanged,
@@ -45,6 +47,7 @@ export {  createMessage,
           receiveCreatedMessage,
           clickThread,
           resetVoice,
+          saveFeedback,
           receiveAll }
 
 export { serverChanged,
@@ -54,6 +57,7 @@ export { serverChanged,
          micInputChanged,
          speechOutputChanged,
          speechOutputAlwaysChanged,
+         sendFeedback,
          themeChanged }
 
 export { connectToWebSocket, sendToHardwareDevice }

--- a/src/components/ChatApp/MessageListItem/Feedback.react.js
+++ b/src/components/ChatApp/MessageListItem/Feedback.react.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ThumbUp from 'material-ui/svg-icons/action/thumb-up';
+import ThumbDown from 'material-ui/svg-icons/action/thumb-down';
+import UserPreferencesStore from '../../../stores/UserPreferencesStore';
+import * as Actions from '../../../actions/';
+
+class Feedback extends React.Component {
+
+	constructor(props){
+		super(props);
+
+	    this.state = {
+	    	ratingGiven: false,
+	    	positive: false,
+	    	negative: false,
+	    	skill: this.parseSkill(),
+	    }
+	}
+
+	parseSkill = () => {
+		let message = this.props.message;
+		let rating ={};
+		if(message.authorName === 'SUSI'){
+			let skill = message.response.answers[0].skills[0];
+			let parsed = skill.split('/');
+			if(parsed.length === 7){
+				rating.model = parsed[3];
+				rating.group = parsed[4];
+				rating.language = parsed[5];
+				rating.skill = parsed[6].slice(0,-4);
+			}
+		}
+		return rating;
+	}
+
+	rateSkill = (rating) => {
+		console.log(rating);
+		switch(rating){
+			case 'positive':{
+				this.setState({
+					ratingGiven: true,
+					positive: true,
+					negative: false,
+				});
+				break;
+			}
+			case 'negative':{
+				this.setState({
+					ratingGiven: true,
+					positive: false,
+					negative: true,
+				});
+				break;
+			}
+			default: {
+				this.setState({
+					ratingGiven: false,
+					positive: false,
+					negative: false,
+				});
+			}
+		}
+		let feedback = this.state.skill;
+		if(!(Object.keys(feedback).length === 0 && feedback.constructor === Object)){
+			feedback.rating = rating;
+			Actions.saveFeedback(feedback);
+		}
+	}
+
+	render(){
+		let message = this.props.message;
+		let latestSUSIMsgID = this.props.latestSUSIMsgID;
+
+		let feedbackButtons = null;
+		let feedbackStyle = {
+			display: 'block',
+			position: 'relative',
+			float: 'right'
+		}
+
+		if(message.authorName === 'SUSI'){
+			let feedbackIndicator = {
+				height:'16px',
+				cursor: 'pointer'
+			}
+
+			let feedbackColor = UserPreferencesStore.getTheme()==='light' ? '#90a4ae' : '#7eaaaf';
+			let positiveFeedbackColor = feedbackColor;
+			let negativeFeedbackColor = feedbackColor;
+			if(this.state.positive){
+				positiveFeedbackColor = UserPreferencesStore.getTheme()==='light' ? '#0000ff' : '#00ff7f';
+			}
+			else if(this.state.negative){
+				negativeFeedbackColor = UserPreferencesStore.getTheme()==='light' ? '#0000ff' : '#00ff7f';
+			}
+
+			if(message.id === latestSUSIMsgID){
+				feedbackButtons = (
+					<li className='message-time' style={feedbackStyle}>
+						<ThumbUp
+							onClick={this.rateSkill.bind(this,'positive')}
+							style={feedbackIndicator}
+							color={positiveFeedbackColor}/>
+						<ThumbDown
+							onClick={this.rateSkill.bind(this,'negative')}
+							style={feedbackIndicator}
+							color={negativeFeedbackColor}/>
+					</li>
+				);
+			}
+		}
+		if(message.authorName === 'You'){
+			feedbackStyle = {};
+		}
+		return(
+			<div>
+				{feedbackButtons}
+			</div>
+		);
+	}
+}
+
+Feedback.propTypes = {
+  message: PropTypes.object,
+  latestSUSIMsgID: PropTypes.string
+};
+
+export default Feedback;

--- a/src/components/ChatApp/MessageListItem/MessageListItem.react.js
+++ b/src/components/ChatApp/MessageListItem/MessageListItem.react.js
@@ -7,8 +7,8 @@ import $ from 'jquery';
 import { imageParse, processText,
   renderTiles, drawMap, drawTable,
   getRSSTiles, renderMessageFooter,
-  renderFeedback } from './helperFunctions.react.js';
-
+} from './helperFunctions.react.js';
+import Feedback from './Feedback.react';
 import VoicePlayer from './VoicePlayer';
 
 const entities = new AllHtmlEntities();
@@ -18,7 +18,7 @@ class MessageListItem extends React.Component {
   constructor(props){
     super(props);
     this.state = {
-      play: false
+      play: false,
     }
   }
 
@@ -117,7 +117,9 @@ class MessageListItem extends React.Component {
                   <section  className={messageContainerClasses}>
                   <div className='message-text'>{replacedText}</div>
                     {renderMessageFooter(message,latestUserMsgID)}
-                    {renderFeedback(message, latestSUSIMsgID)}
+                    <Feedback
+                      message={message}
+                      latestSUSIMsgID={latestSUSIMsgID}/>
                   </section>
                 </li>
               );
@@ -134,7 +136,9 @@ class MessageListItem extends React.Component {
                       rel='noopener noreferrer'>{text}</a>
                   </div>
                     {renderMessageFooter(message,latestUserMsgID)}
-                    {renderFeedback(message, latestSUSIMsgID)}
+                    <Feedback
+                      message={message}
+                      latestSUSIMsgID={latestSUSIMsgID}/>
                   </section>
                 </li>
               );
@@ -158,7 +162,9 @@ class MessageListItem extends React.Component {
                         <section className={messageContainerClasses}>
                         <div>{mymap}</div>
                           {renderMessageFooter(message,latestUserMsgID)}
-                          {renderFeedback(message, latestSUSIMsgID)}
+                          <Feedback
+                            message={message}
+                            latestSUSIMsgID={latestSUSIMsgID}/>
                         </section>
                       </li>
                       );
@@ -176,7 +182,9 @@ class MessageListItem extends React.Component {
                   <section className={messageContainerClasses}>
                   <div>{mymap}</div>
                     {renderMessageFooter(message,latestUserMsgID)}
-                    {renderFeedback(message, latestSUSIMsgID)}
+                    <Feedback
+                      message={message}
+                      latestSUSIMsgID={latestSUSIMsgID}/>
                   </section>
                 </li>
                 );
@@ -191,7 +199,9 @@ class MessageListItem extends React.Component {
                   <section className={messageContainerClasses}>
                   <div><div className='message-text'>{table}</div></div>
                     {renderMessageFooter(message,latestUserMsgID)}
-                    {renderFeedback(message, latestSUSIMsgID)}
+                    <Feedback
+                      message={message}
+                      latestSUSIMsgID={latestSUSIMsgID}/>
                   </section>
                 </li>
               );
@@ -213,7 +223,9 @@ class MessageListItem extends React.Component {
                       {renderTiles(rssTiles)}
                     </div></div>
                       {renderMessageFooter(message,latestUserMsgID)}
-                      {renderFeedback(message, latestSUSIMsgID)}
+                      <Feedback
+                        message={message}
+                        latestSUSIMsgID={latestSUSIMsgID}/>
                     </section>
                   </li>
                 );
@@ -228,7 +240,9 @@ class MessageListItem extends React.Component {
                       {renderTiles(websearchTiles)}
                     </div></div>
                       {renderMessageFooter(message,latestUserMsgID)}
-                      {renderFeedback(message, latestSUSIMsgID)}
+                      <Feedback
+                        message={message}
+                        latestSUSIMsgID={latestSUSIMsgID}/>
                     </section>
                   </li>
                 );
@@ -257,7 +271,9 @@ class MessageListItem extends React.Component {
         <section  className={messageContainerClasses}>
         <div className='message-text'>{replacedText}</div>
           {renderMessageFooter(message,latestUserMsgID)}
-          {renderFeedback(message, latestSUSIMsgID)}
+          <Feedback
+            message={message}
+            latestSUSIMsgID={latestSUSIMsgID}/>
         </section>
       </li>
     );

--- a/src/components/ChatApp/MessageListItem/helperFunctions.react.js
+++ b/src/components/ChatApp/MessageListItem/helperFunctions.react.js
@@ -16,8 +16,6 @@ import Paper from 'material-ui/Paper';
 import Slider from 'react-slick';
 import TickIcon from 'material-ui/svg-icons/action/done';
 import ClockIcon from 'material-ui/svg-icons/action/schedule';
-import ThumbUp from 'material-ui/svg-icons/action/thumb-up';
-import ThumbDown from 'material-ui/svg-icons/action/thumb-down';
 import UserPreferencesStore from '../../../stores/UserPreferencesStore';
 import Parser from 'html-react-parser';
 
@@ -30,42 +28,7 @@ class ExtendedMarker extends Marker {
     this.leafletElement.openPopup();
   }
 }
-// Return the Feedback State
-export function renderFeedback(message, latestSUSIMsgID) {
 
-  let feedbackButtons = null;
-  let feedbackStyle = {
-    display: 'block',
-    position: 'relative',
-    float: 'right'
-  }
-  if(message.authorName === 'SUSI'){
-    let feedbackIndicator = {
-      height:'16px',
-      cursor: 'pointer'
-    }
-
-    if(message.id === latestSUSIMsgID){
-      feedbackButtons = (
-      <li className='message-time' style={feedbackStyle}>
-        <ThumbUp style={feedbackIndicator}
-          color={UserPreferencesStore.getTheme()==='light' ? '#90a4ae' : '#7eaaaf'}/>
-        <ThumbDown style={feedbackIndicator}
-          color={UserPreferencesStore.getTheme()==='light' ? '#90a4ae' : '#7eaaaf'}/>
-      </li>);
-    }
-  }
-  if(message.authorName === 'SUSI'){
-    feedbackStyle = {};
-  }
-  return(
-    <div>
-      {feedbackButtons}
-    </div>
-  );
-
-
-}
 // Returns the message time and status indicator
 export function renderMessageFooter(message,latestMsgID){
 

--- a/src/constants/ChatConstants.js
+++ b/src/constants/ChatConstants.js
@@ -18,6 +18,7 @@ export default {
     SPEECH_OUTPUT_ALWAYS_CHANGED: null,
     INIT_SETTINGS: null,
     RESET_MESSAGE_VOICE: null,
+    FEEDBACK_RECEIVED: null,
   })
 
 };

--- a/src/stores/MessageStore.js
+++ b/src/stores/MessageStore.js
@@ -8,6 +8,7 @@ let ActionTypes = ChatConstants.ActionTypes;
 let CHANGE_EVENT = 'change';
 
 let _messages = {};
+let _feedback = {};
 let _showLoading = false;
 
 function _markAllInThreadRead(threadID) {
@@ -75,6 +76,10 @@ let MessageStore = {
 
   getLoadStatus(){
     return _showLoading;
+  },
+
+  getFeedback(){
+    return _feedback;
   },
 
   /**
@@ -150,6 +155,7 @@ MessageStore.dispatchToken = ChatAppDispatcher.register(action => {
       MessageStore.resetVoiceForThread(message.threadID);
       _messages[message.id] = message;
       _showLoading = false;
+      _feedback = {};
       MessageStore.emitChange();
       break;
     }
@@ -163,6 +169,13 @@ MessageStore.dispatchToken = ChatAppDispatcher.register(action => {
 
     case ActionTypes.RESET_MESSAGE_VOICE: {
       MessageStore.resetVoiceForCurrentThread();
+      MessageStore.emitChange();
+      break;
+    }
+
+    case ActionTypes.FEEDBACK_RECEIVED: {
+      _feedback = action.feedback;
+      console.log(_feedback);
       MessageStore.emitChange();
       break;
     }


### PR DESCRIPTION
Fixes issue #469

**Changes:**
* Users can now like or dislike the responses
* Moved feedback UI to a new component to maintain like dislike state and highlight the icons accordingly
* Store the feedback until the user sends another message so as to enable the user to change his feedback and not make multiple calls for every change and only send the final feedback once to the server i.e when the user sends a new message, send the feedback of previous response to the server

**Demo Link:** http://susifeedback.surge.sh/

**Screenshots for the change:** 

![up](https://user-images.githubusercontent.com/13276887/28162812-0b8e6650-67e6-11e7-91a4-dd9a1a2d269a.png)

![down](https://user-images.githubusercontent.com/13276887/28162817-11227110-67e6-11e7-85c5-72d2714b846f.png)
