### PR TITLE
Fixes #477 - Added settings to adjust rate and pitch for text to speech

### DIFF
--- a/src/__tests__/components/Settings.js
+++ b/src/__tests__/components/Settings.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Settings from '../../components/ChatApp/Settings.react';
+import Settings from '../../components/ChatApp/Settings/Settings.react';
 import { shallow } from 'enzyme';
 
  it('render Settings without crashing',()=>{

--- a/src/actions/Settings.actions.js
+++ b/src/actions/Settings.actions.js
@@ -51,6 +51,20 @@ export function speechOutputAlwaysChanged(speechOutputAlways) {
   Actions.setSpeechOutputAlwaysSettings(speechOutputAlways);
 }
 
+export function speechRateChanged(rate) {
+  ChatAppDispatcher.dispatch({
+    type: ActionTypes.SPEECH_RATE_CHANGED,
+    rate
+  });
+}
+
+export function speechPitchChanged(pitch) {
+  ChatAppDispatcher.dispatch({
+    type: ActionTypes.SPEECH_PITCH_CHANGED,
+    pitch
+  });
+}
+
 export function initialiseSettings(settings) {
   ChatAppDispatcher.dispatch({
     type: ActionTypes.INIT_SETTINGS,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -25,6 +25,8 @@ import {  serverChanged,
           micInputChanged,
           speechOutputChanged,
           speechOutputAlwaysChanged,
+          speechRateChanged,
+          speechPitchChanged,
           themeChanged  } from './Settings.actions';
 
 import {  connectToWebSocket,
@@ -57,6 +59,8 @@ export { serverChanged,
          micInputChanged,
          speechOutputChanged,
          speechOutputAlwaysChanged,
+         speechRateChanged,
+         speechPitchChanged,
          sendFeedback,
          themeChanged }
 

--- a/src/components/ChatApp/MessageListItem/MessageListItem.react.js
+++ b/src/components/ChatApp/MessageListItem/MessageListItem.react.js
@@ -10,6 +10,7 @@ import { imageParse, processText,
 } from './helperFunctions.react.js';
 import Feedback from './Feedback.react';
 import VoicePlayer from './VoicePlayer';
+import UserPreferencesStore from '../../../stores/UserPreferencesStore';
 
 const entities = new AllHtmlEntities();
 
@@ -262,6 +263,8 @@ class MessageListItem extends React.Component {
                (<VoicePlayer
                   play
                   text={voiceOutput}
+                  rate={UserPreferencesStore.getSpeechRate()}
+                  pitch={UserPreferencesStore.getSpeechPitch()}
                   onStart={this.onStart}
                   onEnd={this.onEnd}
                 />)}

--- a/src/components/ChatApp/MessageListItem/VoicePlayer.js
+++ b/src/components/ChatApp/MessageListItem/VoicePlayer.js
@@ -26,9 +26,7 @@ class VoicePlayer extends Component {
     }
 
     let speech = new SpeechSynthesisUtterance()
-
     Object.assign(speech, defaults, this.props)
-
     return speech
   }
 
@@ -97,6 +95,8 @@ class VoicePlayer extends Component {
 VoicePlayer.propTypes = {
   play: PropTypes.bool,
   text: PropTypes.string,
+  rate: PropTypes.number,
+  pitch: PropTypes.number,
   onStart: PropTypes.func,
   onEnd: PropTypes.func
 };

--- a/src/components/ChatApp/MessageSection/DialogSection.js
+++ b/src/components/ChatApp/MessageSection/DialogSection.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import Login from '../../Auth/Login/Login.react';
 import SignUp from '../../Auth/SignUp/SignUp.react';
 import ChangePassword from '../../Auth/ChangePassword/ChangePassword.react';
-import Settings from '../Settings.react';
+import Settings from '../Settings/Settings.react';
 import PropTypes from 'prop-types';
 import HardwareComponent from '../HardwareComponent';
 

--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -380,6 +380,20 @@ class MessageSection extends Component {
     }
   }
 
+  changeSpeechRate = (rate) => {
+    let currSpeechRate = UserPreferencesStore.getSpeechRate();
+    if(currSpeechRate !== rate){
+      Actions.speechRateChanged(rate);
+    }
+  }
+
+  changeSpeechPitch = (pitch) => {
+    let currSpeechPitch = UserPreferencesStore.getSpeechPitch();
+    if(currSpeechPitch !== pitch){
+      Actions.speechPitchChanged(pitch);
+    }
+  }
+
   serverSettingChanged = () => {
     this.setState({
       showSettings: false,
@@ -442,6 +456,8 @@ class MessageSection extends Component {
     this.changeMicInput(values.micInput);
     this.changeSpeechOutput(values.speechOutput);
     this.changeSpeechOutputAlways(values.speechOutputAlways);
+    this.changeSpeechRate(values.rate);
+    this.changeSpeechPitch(values.pitch);
     setTimeout(() => {
        this.setState({
            SnackbarOpen: false

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -7,9 +7,11 @@ import MenuItem from 'material-ui/MenuItem';
 import PropTypes from 'prop-types';
 import TextField from 'material-ui/TextField';
 import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
-import UserPreferencesStore from '../../stores/UserPreferencesStore';
+import UserPreferencesStore from '../../../stores/UserPreferencesStore';
 import Cookies from 'universal-cookie';
 import Toggle from 'material-ui/Toggle';
+import Dialog from 'material-ui/Dialog';
+import TextToSpeechSettings from './TextToSpeechSettings.react';
 
 const cookies = new Cookies();
 
@@ -24,6 +26,8 @@ class Settings extends Component {
 		let defaultMicInput = defaults.MicInput;
 		let defaultSpeechOutput = defaults.SpeechOutput;
 		let defaultSpeechOutputAlways = defaults.SpeechOutputAlways;
+		let defaultSpeechRate = defaults.SpeechRate;
+		let defaultSpeechPitch = defaults.SpeechPitch;
 		this.state = {
 			theme: defaultTheme,
 			enterAsSend: defaultEnterAsSend,
@@ -34,7 +38,10 @@ class Settings extends Component {
 			serverUrl: '',
             serverFieldError: false,
             checked: false,
-			validForm: true
+			validForm: true,
+			showLanguageSettings: false,
+			speechRate: defaultSpeechRate,
+			speechPitch: defaultSpeechPitch,
 		};
 
 		this.customServerMessage = '';
@@ -55,6 +62,8 @@ class Settings extends Component {
 		let newMicInput = this.state.micInput;
 		let newSpeechOutput = this.state.speechOutput;
 		let newSpeechOutputAlways = this.state.speechOutputAlways;
+		let newSpeechRate = this.state.speechRate;
+		let newSpeechPitch = this.state.speechPitch;
 		if(newDefaultServer.slice(-1)==='/'){
 			newDefaultServer = newDefaultServer.slice(0,-1);
 		}
@@ -65,6 +74,8 @@ class Settings extends Component {
 			micInput: newMicInput,
 			speechOutput: newSpeechOutput,
 			speechOutputAlways: newSpeechOutputAlways,
+			rate: newSpeechRate,
+			pitch: newSpeechPitch,
 		}
 		// Store in cookies for anonymous user
 		cookies.set('settings', vals);
@@ -96,6 +107,20 @@ class Settings extends Component {
 	handleSpeechOutputAlways = (event, isInputChecked) => {
 		this.setState({
 			speechOutputAlways: isInputChecked,
+		});
+	}
+
+	handleLanguage = (toShow) => {
+		this.setState({
+			showLanguageSettings: toShow,
+		});
+	}
+
+	handleTextToSpeech = (settings) => {
+		this.setState({
+			speechRate: settings.rate,
+			speechPitch: settings.pitch,
+			showLanguageSettings: false,
 		});
 	}
 
@@ -211,6 +236,14 @@ class Settings extends Component {
 			        		onToggle={this.handleSpeechOutputAlways}
 							toggled={this.state.speechOutputAlways}/>
 			        </div>
+			        <div>
+			    		<h4 style={{'marginBottom':'0px'}}>Language</h4>
+						<FlatButton
+							className='settingsBtns'
+							style={Buttonstyles}
+							label="Select a Language"
+							onClick={this.handleLanguage.bind(this,true)} />
+			    	</div>
 			        {cookies.get('loggedIn') ?
 			        <div>
 			        <h4 style={subHeaderStyle}>Server Settings</h4>
@@ -265,6 +298,16 @@ class Settings extends Component {
 						/>
 					</div>
 				</Paper>
+				<Dialog
+		          modal={false}
+		          autoScrollBodyContent={true}
+		          open={this.state.showLanguageSettings}
+		          onRequestClose={this.handleLanguage.bind(this,false)}>
+		          <TextToSpeechSettings
+		          	rate={this.state.speechRate}
+		          	pitch={this.state.speechPitch}
+		          	ratePitchSettings={this.handleTextToSpeech}/>
+		        </Dialog>
 			</div>);
 	}
 }

--- a/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
+++ b/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
@@ -1,0 +1,161 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Paper from 'material-ui/Paper';
+import UserPreferencesStore from '../../../stores/UserPreferencesStore';
+import Slider from 'material-ui/Slider';
+import FlatButton from 'material-ui/FlatButton';
+import RaisedButton from 'material-ui/RaisedButton';
+import VoicePlayer from '../MessageListItem/VoicePlayer';
+
+class TextToSpeechSettings extends Component {
+
+	constructor(props) {
+		super(props);
+		this.state = {
+			rate: this.props.rate,
+			pitch: this.props.pitch,
+			play: false,
+			playExample:false,
+		};
+		this.speechSynthesisExample = 'This is an example of speech synthesis in English';
+	}
+
+	onStart = () => {
+		this.setState({
+			play: true
+		});
+	}
+
+	onEnd = () => {
+		this.setState({
+			play: false,
+			playExample: false,
+		});
+	}
+
+	handleRate = (event, value) => {
+		this.setState({
+			rate: value,
+		});
+	};
+
+	handlePitch = (event, value) => {
+		this.setState({
+			pitch: value,
+		});
+	};
+
+	resetRate = () => {
+		this.setState({
+			rate: 1,
+		});
+	}
+
+	resetPitch = () => {
+		this.setState({
+			pitch: 1,
+		});
+	}
+
+	playDemo = () => {
+		this.setState({
+			playExample: true,
+			play:true,
+		});
+	}
+
+	handleSubmit = () => {
+		this.props.ratePitchSettings({
+			rate: this.state.rate,
+			pitch: this.state.pitch,
+		});
+	}
+
+	render() {
+
+		const Buttonstyles = {
+			marginBottom: 16,
+		}
+
+		const subHeaderStyle = {
+			color: UserPreferencesStore.getTheme()==='light'
+								? '#607D8B' : '#19314B'
+		}
+
+		return (
+			<div className="settingsForm">
+				<Paper zDepth={0}>
+					<h1 style={{textAlign: 'center'}}>Text-To-Speech Settings</h1>
+					<h4 style={subHeaderStyle}>General</h4>
+			        <div>
+			        	<h4 style={{'marginBottom':'0px'}}>Speech Rate</h4>
+			        	<Slider
+			        		min={0.1}
+			        		max={5}
+			        		value={this.state.rate}
+			        		onChange={this.handleRate} />
+			        </div>
+			        <div>
+			        	<h4 style={{'marginBottom':'0px'}}>Pitch</h4>
+			        	<Slider
+			        		min={0}
+			        		max={2}
+			        		value={this.state.pitch}
+			        		onChange={this.handlePitch} />
+			        </div>
+			        <div>
+			    		<h4 style={{'marginBottom':'0px'}}>Reset Speech Rate</h4>
+						<FlatButton
+							className='settingsBtns'
+							style={Buttonstyles}
+							label="Reset the speed at which the text is spoken to normal"
+							onClick={this.resetRate} />
+			    	</div>
+			    	<div>
+			    		<h4 style={{'marginBottom':'0px'}}>Reset Speech Pitch</h4>
+						<FlatButton
+							className='settingsBtns'
+							style={Buttonstyles}
+							label="Reset the pitch at which the text is spoken to default"
+							onClick={this.resetPitch} />
+			    	</div>
+			    	<div>
+			    		<h4 style={{'marginBottom':'0px'}}>Listen to an example</h4>
+						<FlatButton
+							className='settingsBtns'
+							style={Buttonstyles}
+							label="Play a short demonstration of speech synthesis"
+							onClick={this.playDemo} />
+			    	</div>
+			    	<div style={{textAlign: 'center'}}>
+						<RaisedButton
+							label="Save"
+							backgroundColor={
+								UserPreferencesStore.getTheme()==='light'
+								? '#607D8B' : '#19314B'}
+							labelColor="#fff"
+							onClick={this.handleSubmit}
+						/>
+					</div>
+				</Paper>
+				{ this.state.playExample &&
+	               (<VoicePlayer
+	                  play={this.state.play}
+	                  text={this.speechSynthesisExample}
+	                  rate={this.state.rate}
+	                  pitch={this.state.pitch}
+	                  onStart={this.onStart}
+	                  onEnd={this.onEnd}
+	                />)
+	           }
+			</div>);
+	}
+}
+
+TextToSpeechSettings.propTypes = {
+	rate: PropTypes.number,
+	pitch: PropTypes.number,
+	ratePitchSettings: PropTypes.func,
+};
+
+export default TextToSpeechSettings;

--- a/src/constants/ChatConstants.js
+++ b/src/constants/ChatConstants.js
@@ -19,6 +19,8 @@ export default {
     INIT_SETTINGS: null,
     RESET_MESSAGE_VOICE: null,
     FEEDBACK_RECEIVED: null,
+    SPEECH_RATE_CHANGED: null,
+    SPEECH_PITCH_CHANGED: null,
   })
 
 };

--- a/src/stores/UserPreferencesStore.js
+++ b/src/stores/UserPreferencesStore.js
@@ -13,6 +13,8 @@ let _defaults = {
     MicInput: true,
     SpeechOutput: true,
     SpeechOutputAlways: false,
+    SpeechRate: 1,
+    SpeechPitch: 1,
 };
 
 let UserPreferencesStore = {
@@ -44,6 +46,14 @@ let UserPreferencesStore = {
 
     getSpeechOutputAlways(){
         return _defaults.SpeechOutputAlways;
+    },
+
+    getSpeechRate(){
+        return _defaults.SpeechRate;
+    },
+
+    getSpeechPitch(){
+        return _defaults.SpeechPitch;
     },
 
     addChangeListener(callback) {
@@ -92,6 +102,18 @@ UserPreferencesStore.dispatchToken = ChatAppDispatcher.register(action => {
 
         case ActionTypes.SPEECH_OUTPUT_ALWAYS_CHANGED: {
             _defaults.SpeechOutputAlways = action.speechOutputAlways;
+            UserPreferencesStore.emitChange();
+            break;
+        }
+
+        case ActionTypes.SPEECH_RATE_CHANGED: {
+            _defaults.SpeechRate = action.rate;
+            UserPreferencesStore.emitChange();
+            break;
+        }
+
+        case ActionTypes.SPEECH_PITCH_CHANGED: {
+            _defaults.SpeechPitch = action.pitch;
             UserPreferencesStore.emitChange();
             break;
         }


### PR DESCRIPTION
Fixes issue #477 

**Changes:**
* Added settings for text to speech
* User can now adjust rate and pitch for speech output
* User can also listen to example speech synthesis output for selected rate and pitch

**Needs to be implemented:**
* Push the settings to server for logged in user
* Store the settings in cookies for anonymous user

**Demo Link:**  http://speechsetting.surge.sh/

**Screenshots for the change:** 

![ratepitch](https://user-images.githubusercontent.com/13276887/28237680-d56f4570-6962-11e7-9030-dbbeb442ff0d.png)

