### PR TITLE
Fixes #492 - implement text-to-speech with correct language

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -30,8 +30,8 @@ export function getLocation(){
       }
     }
   });
-}
 
+}
 export function createSUSIMessage(createdMessage, currentThreadID, voice) {
   var timestamp = Date.now();
   let receivedMessage = {
@@ -45,7 +45,8 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
     date: new Date(timestamp),
     isRead: true,
     type: 'message',
-    voice: voice
+    voice: voice,
+    lang: 'en-US'
     };
 
   let defaults = UserPreferencesStore.getPreferences();
@@ -95,6 +96,13 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
       Actions.sendToHardwareDevice(response);
 
       receivedMessage.text = response.answers[0].actions[0].expression;
+      if(receivedMessage.lang===undefined){
+        receivedMessage.lang = document.documentElement.getAttribute('lang');
+      }
+      else{
+        // Setting Language received from User
+        receivedMessage.lang = response.answers[0].actions[0].language;
+      }
       receivedMessage.response = response;
       let actions = [];
       response.answers[0].actions.forEach((actionobj) => {

--- a/src/components/ChatApp/MessageListItem/VoicePlayer.js
+++ b/src/components/ChatApp/MessageListItem/VoicePlayer.js
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
+import MessageStore from '../../../stores/MessageStore';
 
 class VoicePlayer extends Component {
   constructor (props) {
@@ -22,9 +23,8 @@ class VoicePlayer extends Component {
       volume: 1,
       rate: 1,
       pitch: 1,
-      lang: 'en-US'
+      lang: MessageStore.getLang()
     }
-
     let speech = new SpeechSynthesisUtterance()
     Object.assign(speech, defaults, this.props)
     return speech

--- a/src/stores/MessageStore.js
+++ b/src/stores/MessageStore.js
@@ -6,7 +6,7 @@ import ThreadStore from './ThreadStore';
 
 let ActionTypes = ChatConstants.ActionTypes;
 let CHANGE_EVENT = 'change';
-
+let lang = 'en-US';
 let _messages = {};
 let _feedback = {};
 let _showLoading = false;
@@ -72,6 +72,10 @@ let MessageStore = {
   getAll() {
     return _messages;
 
+  },
+
+  getLang() {
+    return lang
   },
 
   getLoadStatus(){
@@ -152,6 +156,8 @@ MessageStore.dispatchToken = ChatAppDispatcher.register(action => {
 
     case ActionTypes.CREATE_SUSI_MESSAGE: {
       let message = action.message;
+      lang = message.lang;
+      console.log(message.lang);
       MessageStore.resetVoiceForThread(message.threadID);
       _messages[message.id] = message;
       _showLoading = false;

--- a/src/utils/ChatMessageUtils.js
+++ b/src/utils/ChatMessageUtils.js
@@ -35,7 +35,8 @@ export function getSUSIMessageData(message, currentThreadID) {
     isRead: true,
     responseTime: message.responseTime,
     type: 'message',
-    voice: message.voice
+    voice: message.voice,
+    lang: message.lang
   };
   return receivedMessage;
 }


### PR DESCRIPTION
Fixes issue #492 

Changes: 
- Now getting voice outputs based on the lang property in message
```
{
  "query": "hello",
  "count": 1,
  "client_id": "aG9zdF84NC4xODEuMTEyLjEzOA==",
  "query_date": "2017-07-15T21:31:09.833Z",
  "answers": [{
    "data": [{
      "0": "hello",
      "1": "",
      "token_original": "hello",
      "token_canonical": "hello",
      "token_categorized": "hello",
      "timezoneOffset": "-120",
      "language": "en"
    }],
    "metadata": {"count": 1},
    "actions": [{
      "type": "answer",
      "language": "en",
      "expression": "Hello!"
    }],
    "skills": ["/susi_server/conf/susi/en_0700_ai_play.json"]
  }],
  "answer_date": "2017-07-15T21:31:09.855Z",
  "answer_time": 22,
  "language": "en",
  "session": {"identity": {
    "type": "host",
    "name": "xx.xx.xx.xx",
    "anonymous": true
  }}
}
```

Demo Link: 
http://susi-voice.surge.sh


