### PR TITLE
Fixes #512 - Show feedback for the entire conversation

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -47,8 +47,10 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
     type: 'message',
     voice: voice,
     lang: 'en-US',
-    positiveFeedback: 0,
-    negativeFeedback: 0
+    feedback: {
+        isRated: false,
+        rating: null,
+      }
     };
 
   let defaults = UserPreferencesStore.getPreferences();
@@ -94,7 +96,6 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
     timeout: 3000,
     async: false,
     success: function (response) {
-      console.log(response)
       // send susi response to connected Hardware Device
       Actions.sendToHardwareDevice(response);
 
@@ -107,113 +108,64 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
         receivedMessage.lang = response.answers[0].actions[0].language;
       }
       receivedMessage.response = response;
-      if(response.answers[0] !== undefined){
-        let skills = response.answers[0].skills[0];
-        let model = '';
-        let group = '';
-        let skill = '';
-        let parsed = skills.split('/');
-        if(parsed.length === 7){
-          model = parsed[3];
-          group = parsed[4];
-          skill = parsed[6].slice(0,-4);
+      let actions = [];
+      response.answers[0].actions.forEach((actionobj) => {
+        actions.push(actionobj.type);
+      });
+      receivedMessage.actions = actions;
+      if (actions.indexOf('websearch') >= 0) {
+        let actionIndex = actions.indexOf('websearch');
+        let actionJson = response.answers[0].actions[actionIndex];
+        let query = actionJson.query;
+        let count = -1;
+        if(actionJson.hasOwnProperty('count')){
+          count = actionJson.count;
         }
-        let getFeedbackEndPoint = BASE_URL+'/cms/getSkillRating.json?'+
-                    'model='+model+
-                    '&group='+group+
-                    '&skill='+skill;
         $.ajax({
-          url: getFeedbackEndPoint,
+          url: 'http://api.duckduckgo.com/?format=json&q=' + query,
           dataType: 'jsonp',
           crossDomain: true,
           timeout: 3000,
           async: false,
           success: function (data) {
-            console.log(getFeedbackEndPoint)
-            console.log(data);
-            if(data.accepted) {
-              let positiveCount = data.skill_rating.positive;
-              let negativeCount = data.skill_rating.negative;
-              receivedMessage.positiveFeedback = positiveCount;
-              receivedMessage.negativeFeedback = negativeCount;
+            if(count === -1){
+              count = data.RelatedTopics.length+1;
             }
-
-            let actions = [];
-            response.answers[0].actions.forEach((actionobj) => {
-              actions.push(actionobj.type);
-            });
-            receivedMessage.actions = actions;
-            if (actions.indexOf('websearch') >= 0) {
-              let actionIndex = actions.indexOf('websearch');
-              let actionJson = response.answers[0].actions[actionIndex];
-              let query = actionJson.query;
-              let count = -1;
-              if(actionJson.hasOwnProperty('count')){
-                count = actionJson.count;
+            if(count > 0 && data.AbstractText){
+              let abstractTile = {
+                title: '',
+                description: '',
+                link: '',
+                icon: '',
               }
-              $.ajax({
-                url: 'http://api.duckduckgo.com/?format=json&q=' + query,
-                dataType: 'jsonp',
-                crossDomain: true,
-                timeout: 3000,
-                async: false,
-                success: function (webdata) {
-                  if(count === -1){
-                    count = webdata.RelatedTopics.length+1;
-                  }
-                  if(count > 0 && webdata.AbstractText){
-                    let abstractTile = {
-                      title: '',
-                      description: '',
-                      link: '',
-                      icon: '',
-                    }
-                    abstractTile.title = webdata.Heading;
-                    abstractTile.description = webdata.AbstractText;
-                    abstractTile.link = webdata.AbstractURL;
-                    abstractTile.icon = webdata.Image;
-                    receivedMessage.websearchresults.push(abstractTile);
-                    count--;
-                  }
-                  for(var tileKey=0;
-                  tileKey<webdata.RelatedTopics.length && count > 0;
-                  tileKey++) {
-                    let tileData = webdata.RelatedTopics[tileKey];
-                    if(!tileData.hasOwnProperty('Name')){
-                      let websearchTile = {
-                        title: '',
-                        description: '',
-                        link: '',
-                        icon: '',
-                      };
-                      websearchTile.title =
-                        tileData.Result.match(/<a [^>]+>([^<]+)<\/a>/)[1];
-                      websearchTile.description = tileData.Text;
-                      websearchTile.link = tileData.FirstURL;
-                      websearchTile.icon = tileData.Icon.URL;
-                      receivedMessage.websearchresults.push(websearchTile);
-                      count--;
-                    }
-                  }
-                  console.log(receivedMessage);
-                  let message = ChatMessageUtils.getSUSIMessageData(
-                    receivedMessage, currentThreadID);
-                  ChatAppDispatcher.dispatch({
-                    type: ActionTypes.CREATE_SUSI_MESSAGE,
-                    message
-                  });
-                },
-                error: function(xhr, status, error) {
-                    if (xhr.status === 404) {
-                      receivedMessage.text = 'Some error occurred while sending your message!';
-                    }
-                    if (status === 'timeout') {
-                      receivedMessage.text = 'Please check your internet connection';
-                    }
-                }
-              });
+              abstractTile.title = data.Heading;
+              abstractTile.description = data.AbstractText;
+              abstractTile.link = data.AbstractURL;
+              abstractTile.icon = data.Image;
+              receivedMessage.websearchresults.push(abstractTile);
+              count--;
             }
-
+            for(var tileKey=0;
+            tileKey<data.RelatedTopics.length && count > 0;
+            tileKey++) {
+              let tileData = data.RelatedTopics[tileKey];
+              if(!tileData.hasOwnProperty('Name')){
+                let websearchTile = {
+                  title: '',
+                  description: '',
+                  link: '',
+                  icon: '',
+                };
+                websearchTile.title =
+                  tileData.Result.match(/<a [^>]+>([^<]+)<\/a>/)[1];
+                websearchTile.description = tileData.Text;
+                websearchTile.link = tileData.FirstURL;
+                websearchTile.icon = tileData.Icon.URL;
+                receivedMessage.websearchresults.push(websearchTile);
+                count--;
+              }
+            }
+            console.log(receivedMessage);
             let message = ChatMessageUtils.getSUSIMessageData(
               receivedMessage, currentThreadID);
             ChatAppDispatcher.dispatch({
@@ -222,92 +174,16 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
             });
           },
           error: function(xhr, status, error) {
-            console.log(getFeedbackEndPoint)
               if (xhr.status === 404) {
-                console.log('Some error occurred while getting feedback!');
+                receivedMessage.text = 'Some error occurred while sending your message!';
               }
               if (status === 'timeout') {
-                console.log('Please check your internet connection');
+                receivedMessage.text = 'Please check your internet connection';
               }
           }
         });
       }
       else {
-        let actions = [];
-        response.answers[0].actions.forEach((actionobj) => {
-          actions.push(actionobj.type);
-        });
-        receivedMessage.actions = actions;
-        if (actions.indexOf('websearch') >= 0) {
-          let actionIndex = actions.indexOf('websearch');
-          let actionJson = response.answers[0].actions[actionIndex];
-          let query = actionJson.query;
-          let count = -1;
-          if(actionJson.hasOwnProperty('count')){
-            count = actionJson.count;
-          }
-          $.ajax({
-            url: 'http://api.duckduckgo.com/?format=json&q=' + query,
-            dataType: 'jsonp',
-            crossDomain: true,
-            timeout: 3000,
-            async: false,
-            success: function (webdata) {
-              if(count === -1){
-                count = webdata.RelatedTopics.length+1;
-              }
-              if(count > 0 && webdata.AbstractText){
-                let abstractTile = {
-                  title: '',
-                  description: '',
-                  link: '',
-                  icon: '',
-                }
-                abstractTile.title = webdata.Heading;
-                abstractTile.description = webdata.AbstractText;
-                abstractTile.link = webdata.AbstractURL;
-                abstractTile.icon = webdata.Image;
-                receivedMessage.websearchresults.push(abstractTile);
-                count--;
-              }
-              for(var tileKey=0;
-              tileKey<webdata.RelatedTopics.length && count > 0;
-              tileKey++) {
-                let tileData = webdata.RelatedTopics[tileKey];
-                if(!tileData.hasOwnProperty('Name')){
-                  let websearchTile = {
-                    title: '',
-                    description: '',
-                    link: '',
-                    icon: '',
-                  };
-                  websearchTile.title =
-                    tileData.Result.match(/<a [^>]+>([^<]+)<\/a>/)[1];
-                  websearchTile.description = tileData.Text;
-                  websearchTile.link = tileData.FirstURL;
-                  websearchTile.icon = tileData.Icon.URL;
-                  receivedMessage.websearchresults.push(websearchTile);
-                  count--;
-                }
-              }
-              console.log(receivedMessage);
-              let message = ChatMessageUtils.getSUSIMessageData(
-                receivedMessage, currentThreadID);
-              ChatAppDispatcher.dispatch({
-                type: ActionTypes.CREATE_SUSI_MESSAGE,
-                message
-              });
-            },
-            error: function(xhr, status, error) {
-                if (xhr.status === 404) {
-                  receivedMessage.text = 'Some error occurred while sending your message!';
-                }
-                if (status === 'timeout') {
-                  receivedMessage.text = 'Please check your internet connection';
-                }
-            }
-          });
-        }
         let message = ChatMessageUtils.getSUSIMessageData(
           receivedMessage, currentThreadID);
         ChatAppDispatcher.dispatch({
@@ -323,7 +199,6 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
     }
   });
 };
-
 
 // Get Settings From Server or Cookies if not loggedIn
 export function getSettings(){
@@ -449,7 +324,6 @@ export function sendFeedback(){
   if(feedback===null){
     return;
   }
-  console.log(feedback);
   if(Object.keys(feedback).length === 0 && feedback.constructor === Object){
     return;
   }

--- a/src/actions/History.actions.js
+++ b/src/actions/History.actions.js
@@ -50,7 +50,12 @@ export function getHistory() {
           websearchresults: [],
           date: '',
           isRead: true,
-          type: 'message'
+          type: 'message',
+          lang: 'en-US',
+          feedback: {
+              isRated: true,
+              rating: null,
+            }
         };
 
         let userMsg = {

--- a/src/components/ChatApp/MessageListItem/Feedback.react.js
+++ b/src/components/ChatApp/MessageListItem/Feedback.react.js
@@ -13,7 +13,6 @@ class Feedback extends React.Component {
 		if(message.authorName === 'SUSI'){
 			if(message.response.answers[0].skills!==undefined){
 				let skill = message.response.answers[0].skills[0];
-				console.log(skill);
 				let parsed = skill.split('/');
 				if(parsed.length === 7){
 					rating.model = parsed[3];
@@ -40,7 +39,6 @@ class Feedback extends React.Component {
 	}
 
 	rateSkill = (rating) => {
-		console.log(rating);
 		switch(rating){
 			case 'positive':{
 				this.setState({
@@ -69,6 +67,7 @@ class Feedback extends React.Component {
 		let feedback = this.state.skill;
 		if(!(Object.keys(feedback).length === 0 && feedback.constructor === Object)){
 			feedback.rating = rating;
+			this.props.message.feedback.rating = rating;
 			Actions.saveFeedback(feedback);
 		}
 	}
@@ -112,6 +111,19 @@ class Feedback extends React.Component {
 							color={negativeFeedbackColor}/>
 					</span>
 				);
+			if(message.feedback.isRated){
+				feedbackIndicator.cursor = 'auto';
+				feedbackButtons = (
+					<span className='message-time' style={feedbackStyle}>
+						<ThumbUp
+							style={feedbackIndicator}
+							color={positiveFeedbackColor}/>
+						<ThumbDown
+							style={feedbackIndicator}
+							color={negativeFeedbackColor}/>
+					</span>
+				);
+			}
 		}
 		if(message.authorName === 'You'){
 			feedbackStyle = {};
@@ -126,7 +138,6 @@ class Feedback extends React.Component {
 
 Feedback.propTypes = {
   message: PropTypes.object,
-  latestSUSIMsgID: PropTypes.string
 };
 
 export default Feedback;

--- a/src/components/ChatApp/MessageListItem/MessageListItem.react.js
+++ b/src/components/ChatApp/MessageListItem/MessageListItem.react.js
@@ -37,10 +37,7 @@ class MessageListItem extends React.Component {
     if(this.props.latestUserMsgID){
       latestUserMsgID = this.props.latestUserMsgID;
     }
-    let latestSUSIMsgID = null;
-    if(this.props.latestSUSIMsgID){
-      latestSUSIMsgID = this.props.latestSUSIMsgID;
-    }
+
     if(this.props.message.type === 'date'){
       return(
         <li className='message-list-item'>
@@ -115,7 +112,7 @@ class MessageListItem extends React.Component {
                 <li className='message-list-item' key={action+index}>
                   <section  className={messageContainerClasses}>
                   <div className='message-text'>{replacedText}</div>
-                    {renderMessageFooter(message,latestUserMsgID,latestSUSIMsgID)}
+                    {renderMessageFooter(message,latestUserMsgID)}
                   </section>
                 </li>
               );
@@ -131,7 +128,7 @@ class MessageListItem extends React.Component {
                     <a href={link} target='_blank'
                       rel='noopener noreferrer'>{text}</a>
                   </div>
-                    {renderMessageFooter(message,latestUserMsgID,latestSUSIMsgID)}
+                    {renderMessageFooter(message,latestUserMsgID)}
                   </section>
                 </li>
               );
@@ -154,7 +151,7 @@ class MessageListItem extends React.Component {
                       <li className='message-list-item' key={action+index}>
                         <section className={messageContainerClasses}>
                         <div>{mymap}</div>
-                          {renderMessageFooter(message,latestUserMsgID,latestSUSIMsgID)}
+                          {renderMessageFooter(message,latestUserMsgID)}
                         </section>
                       </li>
                       );
@@ -171,7 +168,7 @@ class MessageListItem extends React.Component {
                 <li className='message-list-item' key={action+index}>
                   <section className={messageContainerClasses}>
                   <div>{mymap}</div>
-                    {renderMessageFooter(message,latestUserMsgID,latestSUSIMsgID)}
+                    {renderMessageFooter(message,latestUserMsgID)}
                   </section>
                 </li>
                 );
@@ -185,7 +182,7 @@ class MessageListItem extends React.Component {
                 <li className='message-list-item' key={action+index}>
                   <section className={messageContainerClasses}>
                   <div><div className='message-text'>{table}</div></div>
-                    {renderMessageFooter(message,latestUserMsgID,latestSUSIMsgID)}
+                    {renderMessageFooter(message,latestUserMsgID)}
                   </section>
                 </li>
               );
@@ -206,7 +203,7 @@ class MessageListItem extends React.Component {
                     <div><div className='message-text'>
                       {renderTiles(rssTiles)}
                     </div></div>
-                      {renderMessageFooter(message,latestUserMsgID,latestSUSIMsgID)}
+                      {renderMessageFooter(message,latestUserMsgID)}
                     </section>
                   </li>
                 );
@@ -220,7 +217,7 @@ class MessageListItem extends React.Component {
                     <div><div className='message-text'>
                       {renderTiles(websearchTiles)}
                     </div></div>
-                      {renderMessageFooter(message,latestUserMsgID,latestSUSIMsgID)}
+                      {renderMessageFooter(message,latestUserMsgID)}
                     </section>
                   </li>
                 );
@@ -254,7 +251,7 @@ class MessageListItem extends React.Component {
       <li className='message-list-item'>
         <section  className={messageContainerClasses}>
         <div className='message-text'>{replacedText}</div>
-          {renderMessageFooter(message,latestUserMsgID,latestSUSIMsgID)}
+          {renderMessageFooter(message,latestUserMsgID)}
         </section>
       </li>
     );
@@ -266,7 +263,6 @@ MessageListItem.propTypes = {
   message: PropTypes.object,
   markID: PropTypes.string,
   latestUserMsgID: PropTypes.string,
-  latestSUSIMsgID: PropTypes.string
 };
 
 export default MessageListItem;

--- a/src/components/ChatApp/MessageListItem/helperFunctions.react.js
+++ b/src/components/ChatApp/MessageListItem/helperFunctions.react.js
@@ -31,7 +31,7 @@ class ExtendedMarker extends Marker {
 }
 
 // Returns the message time and status indicator
-export function renderMessageFooter(message,latestMsgID,latestSUSIMsgID){
+export function renderMessageFooter(message,latestMsgID){
 
   let statusIndicator = null;
 
@@ -71,8 +71,7 @@ export function renderMessageFooter(message,latestMsgID,latestSUSIMsgID){
           { hour: 'numeric',minute:'numeric', hour12: true }
         )}
         <Feedback
-          message={message}
-          latestSUSIMsgID={latestSUSIMsgID}/>
+          message={message} />
       </li>
       {statusIndicator}
     </ul>

--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -71,15 +71,6 @@ function getMessageListItem(messages, showLoading, markID) {
     });
   }
 
-  // Get message ID of SUSI's Message
-  let latestSUSIMsgID = null;
-  if(messages){
-    let msgCount = messages.length;
-    if(msgCount>0){
-      let latestSUSIMsg = messages[msgCount-1];
-      latestSUSIMsgID = latestSUSIMsg.id;
-    }
-  }
   // Get message ID waiting for server response
   let latestUserMsgID = null;
   if(showLoading && messages){
@@ -96,7 +87,6 @@ function getMessageListItem(messages, showLoading, markID) {
         key={message.id}
         message={message}
         latestUserMsgID={latestUserMsgID}
-        latestSUSIMsgID={latestSUSIMsgID}
       />
     );
   });

--- a/src/stores/MessageStore.js
+++ b/src/stores/MessageStore.js
@@ -117,6 +117,7 @@ let MessageStore = {
       if ((_messages[id].threadID === threadID) &&
           (_messages[id].authorName === 'SUSI')) {
           _messages[id].voice = false;
+          _messages[id].feedback.isRated = true;
       }
     }
   },
@@ -181,7 +182,6 @@ MessageStore.dispatchToken = ChatAppDispatcher.register(action => {
 
     case ActionTypes.FEEDBACK_RECEIVED: {
       _feedback = action.feedback;
-      console.log(_feedback);
       MessageStore.emitChange();
       break;
     }

--- a/src/utils/ChatMessageUtils.js
+++ b/src/utils/ChatMessageUtils.js
@@ -37,8 +37,7 @@ export function getSUSIMessageData(message, currentThreadID) {
     type: 'message',
     voice: message.voice,
     lang: message.lang,
-    positiveFeedback: message.positiveFeedback,
-    negativeFeedback: message.negativeFeedback
+    feedback: message.feedback,
   };
   return receivedMessage;
 }


### PR DESCRIPTION
Fixes issue #512 

**Changes:**
* Maintains the feedback of messages throughout the conversation
* Only for the latest SUSI Response, the user can toggle feedback for the previous messages the feedback is already recorded so the user cannot change it - toggle is disabled
* For messages loaded from the server as history when the app is initialised, the feedback buttons are disabled.

**Next Steps:**
* Improve the UI for feedback buttons - @rishiraj824 is working on it - https://github.com/fossasia/chat.susi.ai/issues/470

**Demo Link:** http://susifeedback.surge.sh/

**Screenshots for the change:** 

![feedback](https://user-images.githubusercontent.com/13276887/28367860-0b014d78-6cb0-11e7-8614-37d56a0cfb04.png)
