### PR TITLE
Fixes #534 - Chat input field insufficient width

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -457,6 +457,7 @@ header{
   text-align: left;
   color: inherit;
   outline: 0;
+  min-width: 100%;
 }
 
 .dark .message-composer{
@@ -478,26 +479,33 @@ textarea {
   -webkit-box-shadow: none;
   -moz-box-shadow: none;
   box-shadow: none;
-  width: 92%;
+  width: 90%;
   resize: none;
   border-radius: 6px;
   padding-left: 10px;
   padding-top: 10px;
   font-size: 14px;
-  height: 72%;
+  height: 82%;
   background: #fff;
   margin-top: 3px;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 @media only screen and (min-width: 0px) and (max-width: 768px){
   textarea{
-    width: 87%;
+    width: 82%;
   }
   .Modal{
     padding: 5px 5px 5px 20px;
   }
 }
-
+@media only screen and (min-width: 768px) and (max-width: 1024px){
+  textarea{
+    width: 88%;
+  }
+}
 .leaflet-container {
   height: 150px;
   width: 250px;


### PR DESCRIPTION
Fixes issue #534

Changes:
- Fixed text-area width for Mac Chrome
- Fixed grammarly auto-sizing the textbox

Demo Link: 
http://susi-textarea.surge.sh

Screenshots for the change: 
<img width="1280" alt="screen shot 2017-07-20 at 7 27 15 pm" src="https://user-images.githubusercontent.com/11540785/28421191-0db88284-6d82-11e7-88f6-6e6550e770fb.png">
