### PR TITLE
Fixes #569 - Break word for message text

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -405,7 +405,6 @@ header{
 }
 
 .message-container.SUSI>h5,.message-container.SUSI>.message-text {
-  overflow-wrap: break-word;
   padding-right: 16px;
 }
 
@@ -452,6 +451,7 @@ header{
   font-size: 14px;
   margin: 0;
   padding: 0;
+  overflow-wrap: break-word;
 }
 
 .message-pane{


### PR DESCRIPTION
Fixes issue #569 

**Changes:**
* Break line to prevent overflow

**Demo Link:** http://udaytheja.surge.sh/

**Screenshots for the change:** 

![overflow](https://user-images.githubusercontent.com/13276887/28488549-4a946134-6eca-11e7-920d-dd40febf5088.png)

