### PR TITLE
Fixes #588 - Fix repeated speech output on re render

### DIFF
--- a/src/components/ChatApp/MessageListItem/MessageListItem.react.js
+++ b/src/components/ChatApp/MessageListItem/MessageListItem.react.js
@@ -10,6 +10,7 @@ import { imageParse, processText,
 } from './helperFunctions.react.js';
 import VoicePlayer from './VoicePlayer';
 import UserPreferencesStore from '../../../stores/UserPreferencesStore';
+import * as Actions from '../../../actions/';
 
 const entities = new AllHtmlEntities();
 
@@ -28,6 +29,7 @@ class MessageListItem extends React.Component {
 
   onEnd = () => {
     this.setState({ play: false });
+    Actions.resetVoice();
   }
 
   render() {

--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -392,7 +392,6 @@ class MessageSection extends Component {
 
     let currSettings = UserPreferencesStore.getPreferences();
     let settingsChanged = {};
-    let resetVoice = false;
     if(currSettings.Theme !== values.theme){
       settingsChanged.Theme = values.theme;
       let headerColor = '';
@@ -419,11 +418,9 @@ class MessageSection extends Component {
     }
     if(currSettings.SpeechOutput !== values.speechOutput){
       settingsChanged.SpeechOutput = values.speechOutput;
-      resetVoice = true;
     }
     if(currSettings.SpeechOutputAlways !== values.speechOutputAlways){
       settingsChanged.SpeechOutputAlways = values.speechOutputAlways;
-      resetVoice = true;
     }
     if(currSettings.SpeechRate !== values.rate){
       settingsChanged.SpeechRate = values.rate;
@@ -432,9 +429,6 @@ class MessageSection extends Component {
       settingsChanged.SpeechPitch = values.pitch;
     }
     Actions.settingsChanged(settingsChanged);
-    if(resetVoice){
-      Actions.resetVoice();
-    }
 
     setTimeout(() => {
        this.setState({


### PR DESCRIPTION
Fixes issue #588 

**Changes:**
* Reset `voice:true` for all messages after VoicePlayer speech output ends to prevent repeated output on re render

**Demo Link:**  http://udaytheja.surge.sh/

@rishiraj824 @isuruAb @madhavrathi Please review