### PR TITLE
Fixes: #611 - Improve the mobile view of overview page

### DIFF
--- a/src/components/Overview/Overview.css
+++ b/src/components/Overview/Overview.css
@@ -470,6 +470,7 @@ header {
         margin-left: 0%;
     }
 }
+
 @media only screen and (max-width: 800px){
 
     .opensource-logos{
@@ -493,15 +494,23 @@ header {
     .description__text{
         max-width: 100%;
     }
+
     .bots{
         max-width: 500px;
     }
+
     .img-container{
         max-width: 100%;
-       margin: 0 auto;
+       margin: 0 auto 20px auto;
     }
+
     .img-conatainer img{
         margin:auto;
+    }
+    .safty_and_secure{
+        padding: 100px 0 240px 0px;
+        width: 90%;
+        margin: 0 auto;
     }
     .shield{
         margin: 0 auto 140px auto;
@@ -545,6 +554,9 @@ header {
 }
 
 @media only screen and (max-width: 480px){
+    .section-container{
+        padding: 35px 20px 120px;
+    }
    .github_logo img{
         height: 40px;
         margin-left: 0;
@@ -558,5 +570,22 @@ header {
     }
     .opensource-logos{
         text-align: center;
+    }
+    .conversation__description{
+        width: 100% !important;
+    }
+    .img-container{
+        width: 60% !important;
+    }
+    .section_copy{
+        padding: 10px 0 0 0;
+        width: 90%;
+        margin: 0 auto;
+    }
+    .shield{
+        margin: 0 auto 210px auto;
+    }
+    .column_section{
+        min-height: 550px;
     }
 }

--- a/src/components/Overview/Overview.react.js
+++ b/src/components/Overview/Overview.react.js
@@ -158,7 +158,7 @@ class Overview extends Component{
             </div>
             <div className="conversation__description custom_description">
               <div className="description__heading">For all Devices</div>
-              <p className="description__text"><b >SUSI.AI</b> is available for android, iOS devices and also you can use it from <Link to="http://chat.susi.ai">http://chat.susi.ai</Link>
+              <p className="description__text"><b >SUSI.AI</b> is available for any android, iOS device and also you can access the web chat application from this URL <Link to="http://chat.susi.ai">http://chat.susi.ai</Link>
               </p>
             </div>
 
@@ -170,7 +170,8 @@ class Overview extends Component{
               </div>
               <div className="description__heading">Use it in many Languages</div>
               <p className="description__text">You can use <b>SUSI.AI</b> in DIfferent
-                     languages
+                     languages. You can ask questions in many languages.
+SUSI is interligent to identify and answer your question in you language.
                     </p>
             </div>
 


### PR DESCRIPTION
Fixes issue #611 

Changes: increase the height of "Safe and Secure" area on mobile screen

Demo Link: http://isuruab.surge.sh/

Screenshots for the change: 
<img width="390" alt="screen shot 2017-07-26 at 10 56 06 pm" src="https://user-images.githubusercontent.com/7692626/28634708-b44c7a10-7255-11e7-9cc8-2fda33a43bcb.png">

@uday96  @rishiraj824  @madhavrathi  please review