### PR TITLE
Fixes #637 Fixed size of chat examples images in overview page

### DIFF
--- a/src/components/Support/Support.css
+++ b/src/components/Support/Support.css
@@ -32,7 +32,7 @@
     letter-spacing: -.01em;
     margin: 40px 0 20px;
 }
-.img-container {
+.image-container {
     width: 30%;
 }
 .blue-text{

--- a/src/components/Support/Support.react.js
+++ b/src/components/Support/Support.react.js
@@ -78,7 +78,7 @@ class Support extends Component {
                   community and team through various channels.
                   </p>
                 </div>
-                <div className='img-container'>
+                <div className='image-container'>
                   <img src={support} alt='support' className='support' />
                 </div>
               </div>


### PR DESCRIPTION
Fixes issue #637 

Changes: Fixed size of chat examples image in overview page.

Demo Link: http://susisizefix.surge.sh/overview

Screenshots for the change: 
![heo](https://user-images.githubusercontent.com/22375731/28752368-ac15c0ee-753a-11e7-94f2-3a624494c3ac.png)

@mariobehling @rishiraj824 @uday96 @isuruAb Please review.
Thanks
