### PR TITLE
[WIP] Fixes #575 - Propose and implement internationalization support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-emojione": "^3.1.10",
     "react-fittext": "^1.0.0",
     "react-headroom": "^2.1.6",
+    "react-intl": "^2.3.0",
     "react-leaflet": "^1.1.6",
     "react-linkify": "^0.2.1",
     "react-modal": "^2.2.2",

--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -62,6 +62,7 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
     };
 
   let defaults = UserPreferencesStore.getPreferences();
+  console.log(defaults);
   let defaultServerURL = defaults.Server;
   let BASE_URL = '';
   if(cookies.get('serverUrl')===defaultServerURL||
@@ -114,6 +115,26 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
         // Setting Language received from User
         receivedMessage.lang = response.answers[0].actions[0].language;
       }
+      let defaultPrefLanguage = defaults.PrefLanguage;
+      // Translate the message text
+        let urlForTranslate = 'https://translate.googleapis.com/translate_a/single?client=gtx&sl=en-US&tl='+defaultPrefLanguage+'&dt=t&q='+receivedMessage.text;
+        $.ajax({
+          url: urlForTranslate,
+          dataType: 'json',
+          crossDomain: true,
+          timeout: 3000,
+          async: false,
+          success: function (data) {
+            if(data[0]){
+              if(data[0][0]){
+                receivedMessage.text = data[0][0][0];
+              }
+            }
+          },
+          error: function(errorThrown){
+            console.log(errorThrown);
+          }
+        });
       receivedMessage.response = response;
       let actions = [];
       response.answers[0].actions.forEach((actionobj) => {
@@ -285,7 +306,7 @@ export function pushSettingsToServer(settings){
     cookies.get('loggedIn')===undefined) {
     return;
   }
-
+  console.log(settings);
   Object.keys(settings).forEach((key) => {
     switch(key){
       case 'Theme':{
@@ -352,6 +373,14 @@ export function pushSettingsToServer(settings){
         makeServerCall(url);
         break;
       }
+      case 'PrefLanguage':{
+        url = BASE_URL+'/aaa/changeUserSettings.json?'
+          +'key=pref_lang&value='+settings.PrefLanguage
+          +'&access_token='+cookies.get('loggedIn');
+        console.log(url);
+        makeServerCall(url);
+        break;
+      }
       default: {
         // do nothing
       }
@@ -389,6 +418,7 @@ export function sendFeedback(){
 }
 
 export function makeServerCall(url){
+  console.log(url)
   $.ajax({
     url: url,
     dataType: 'jsonp',

--- a/src/actions/History.actions.js
+++ b/src/actions/History.actions.js
@@ -74,11 +74,52 @@ export function getHistory() {
         userMsg.date = new Date(cognition.query_date);
         userMsg.text = query;
 
+        // Translate history
+        let defaultPrefLanguage = defaults.PrefLanguage;
+        // Translate the User message text
+        let urlForTranslate = 'https://translate.googleapis.com/translate_a/single?client=gtx&sl=en-US&tl='+defaultPrefLanguage+'&dt=t&q='+userMsg.text;
+        $.ajax({
+          url: urlForTranslate,
+          dataType: 'json',
+          crossDomain: true,
+          timeout: 3000,
+          async: false,
+          success: function (response) {
+            if(response[0]){
+              if(response[0][0]){
+                userMsg.text = response[0][0][0];
+              }
+            }
+          },
+          error: function(errorThrown){
+            console.log(errorThrown);
+          }
+        });
+
         susiMsg.id = 'm_' + Date.parse(cognition.answer_date);
         susiMsg.date = new Date(cognition.answer_date);
         susiMsg.text = cognition.answers[0].actions[0].expression;
         susiMsg.response = cognition;
 
+        // Translate the SUSI message text
+        urlForTranslate = 'https://translate.googleapis.com/translate_a/single?client=gtx&sl=en-US&tl='+defaultPrefLanguage+'&dt=t&q='+susiMsg.text;
+        $.ajax({
+          url: urlForTranslate,
+          dataType: 'json',
+          crossDomain: true,
+          timeout: 3000,
+          async: false,
+          success: function (response) {
+            if(response[0]){
+              if(response[0][0]){
+                susiMsg.text = response[0][0][0];
+              }
+            }
+          },
+          error: function(errorThrown){
+            console.log(errorThrown);
+          }
+        });
         let actions = [];
         cognition.answers[0].actions.forEach((actionObj) => {
           actions.push(actionObj.type);

--- a/src/components/ChatApp/MessageListItem/MessageListItem.react.js
+++ b/src/components/ChatApp/MessageListItem/MessageListItem.react.js
@@ -11,6 +11,21 @@ import { imageParse, processText,
 import VoicePlayer from './VoicePlayer';
 import UserPreferencesStore from '../../../stores/UserPreferencesStore';
 import * as Actions from '../../../actions/';
+import { injectIntl } from 'react-intl';
+// Format Date for internationalization
+const PostDate = injectIntl(({date, intl}) => (
+            <span title={intl.formatDate(date, {
+                year: 'numeric',
+                month: 'numeric',
+                day: 'numeric',
+            })}>
+            {intl.formatDate(date, {
+                year: 'numeric',
+                month: 'numeric',
+                day: 'numeric',
+            })}
+            </span>
+));
 
 const entities = new AllHtmlEntities();
 
@@ -45,7 +60,7 @@ class MessageListItem extends React.Component {
         <li className='message-list-item'>
           <section  className='container-date'>
           <div className='message-text'>
-            {message.date.toLocaleDateString()}
+            <PostDate date={message.date}/>
           </div>
           </section>
         </li>

--- a/src/components/ChatApp/MessageListItem/helperFunctions.react.js
+++ b/src/components/ChatApp/MessageListItem/helperFunctions.react.js
@@ -19,6 +19,9 @@ import TickIcon from 'material-ui/svg-icons/action/done';
 import ClockIcon from 'material-ui/svg-icons/action/schedule';
 import UserPreferencesStore from '../../../stores/UserPreferencesStore';
 import Parser from 'html-react-parser';
+import {
+    injectIntl
+} from 'react-intl';
 
 // Keeps the Map Popup open initially
 class ExtendedMarker extends Marker {
@@ -66,10 +69,7 @@ export function renderMessageFooter(message,latestMsgID, isLastAction){
   return(
     <ul>
       <li className='message-time' style={footerStyle}>
-        {message.date.toLocaleString(
-          'en-US',
-          { hour: 'numeric',minute:'numeric', hour12: true }
-        )}
+        <PostDate date={message.date} />
         { isLastAction &&
           (<Feedback message={message} />)
         }
@@ -78,6 +78,17 @@ export function renderMessageFooter(message,latestMsgID, isLastAction){
     </ul>
   );
 }
+// Format Date for internationalization
+const PostDate = injectIntl(({date, intl}) => (
+            <span title={intl.formatDate(date,{
+            hour: 'numeric',
+            minute: 'numeric',
+        })}>  {intl.formatDate(date,{
+            hour: 'numeric',
+            minute: 'numeric',
+        })}
+        </span>
+));
 
 // Proccess the text for HTML Spl Chars, Images, Links and Emojis
 export function processText(text,type){

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -80,6 +80,7 @@ class Settings extends Component {
 		let defaultSpeechRate = defaults.SpeechRate;
 		let defaultSpeechPitch = defaults.SpeechPitch;
 		let defaultTTSLanguage = defaults.TTSLanguage;
+		let defaultPrefLanguage = defaults.PrefLanguage;
     let voiceList = MessageStore.getTTSVoiceList();
 
     let TTSBrowserSupport;
@@ -89,8 +90,6 @@ class Settings extends Component {
       TTSBrowserSupport = false;
       console.warn('The current browser does not support the SpeechSynthesis API.')
     }
-    console.log(TTSBrowserSupport);
-    console.log(voiceList);
     let STTBrowserSupport;
     const SpeechRecognition = window.SpeechRecognition
       || window.webkitSpeechRecognition
@@ -121,6 +120,7 @@ class Settings extends Component {
 			speechRate: defaultSpeechRate,
 			speechPitch: defaultSpeechPitch,
 			ttsLanguage: defaultTTSLanguage,
+			PrefLanguage: defaultPrefLanguage,
 			showServerChangeDialog: false,
 			showHardwareChangeDialog: false,
 			showChangePasswordDialog: false,
@@ -129,6 +129,7 @@ class Settings extends Component {
 			showForgotPassword: false,
 			showOptions: false,
 			anchorEl: null,
+			voiceList: MessageStore.getTTSVoiceList()
 		};
 
     this.customServerMessage = '';
@@ -177,6 +178,7 @@ class Settings extends Component {
 		let newSpeechRate = this.state.speechRate;
 		let newSpeechPitch = this.state.speechPitch;
 		let newTTSLanguage = this.state.ttsLanguage;
+		let newPrefLanguage = this.state.PrefLanguage;
 		if(newDefaultServer.slice(-1)==='/'){
 			newDefaultServer = newDefaultServer.slice(0,-1);
 		}
@@ -190,17 +192,21 @@ class Settings extends Component {
 			rate: newSpeechRate,
 			pitch: newSpeechPitch,
 			lang: newTTSLanguage,
+			PrefLanguage: newPrefLanguage
 		}
+		console.log(newPrefLanguage);
 
 		let settings = Object.assign({}, vals);
 		settings.LocalStorage = true;
 		// Store in cookies for anonymous user
 		cookies.set('settings',settings);
+		console.log(settings);
 		// Trigger Actions to save the settings in stores and server
 		this.implementSettings(vals);
 	}
 
 	implementSettings = (values) => {
+		console.log(values);
     let currSettings = UserPreferencesStore.getPreferences();
     let settingsChanged = {};
     let resetVoice = false;
@@ -230,11 +236,14 @@ class Settings extends Component {
     if(currSettings.TTSLanguage !== values.lang){
       settingsChanged.TTSLanguage = values.lang;
     }
+    if(currSettings.PrefLanguage !== values.PrefLanguage){
+      settingsChanged.PrefLanguage = values.PrefLanguage;
+    }
     Actions.settingsChanged(settingsChanged);
     if(resetVoice){
       Actions.resetVoice();
     }
-		this.props.history.push('/');
+    this.props.history.push('/');
     window.location.reload();
   }
 
@@ -370,6 +379,11 @@ class Settings extends Component {
     });
 	}
 
+	handlePrefLang = (event, index, value) => {
+		this.setState({
+			PrefLanguage: value,
+		});
+	}
 	closeOptions = () => {
 		this.setState({
       showOptions: false,
@@ -441,6 +455,33 @@ class Settings extends Component {
 				return <Logged />
 	}
 
+	populateVoiceList = () => {
+		let voices = this.state.voiceList;
+		let langCodes = [];
+		let voiceMenu = voices.map((voice,index) => {
+			langCodes.push(voice.lang);
+			return(
+					<MenuItem value={voice.lang} key={index}
+						primaryText={voice.name+' ('+voice.lang+')'} />
+			);
+		});
+		let currLang = this.state.PrefLanguage;
+		let voiceOutput = {
+			voiceMenu: voiceMenu,
+			voiceLang: currLang
+		}
+		// `-` and `_` replacement check of lang codes
+		if(langCodes.indexOf(currLang) === -1){
+			if(currLang.indexOf('-') > -1 && langCodes.indexOf(currLang.replace('-','_')) > -1){
+				voiceOutput.voiceLang = currLang.replace('-','_');
+			}
+			else if(currLang.indexOf('_') > -1 && langCodes.indexOf(currLang.replace('_','-')) > -1){
+				voiceOutput.voiceLang = currLang.replace('_','-');
+			}
+		}
+		console.log(voiceOutput);
+		return voiceOutput;
+	}
 	render() {
 
 		const bodyStyle = {
@@ -542,7 +583,7 @@ class Settings extends Component {
 				</Popover>
 			</div>
 		);
-
+		let voiceOutput = this.populateVoiceList();
 		return (
 			<div className={topBackground}>
 				<header className='message-thread-heading'
@@ -618,6 +659,18 @@ class Settings extends Component {
                 disabled={!this.TTSBrowserSupport}
                 onClick={this.handleLanguage.bind(this,true)} />
             </div>
+           <div>
+                <h3 style={subHeaderStyle}>Language Settings</h3>
+                <div>
+					<h4 style={{'marginBottom':'0px'}}>Select Language</h4>
+					<DropDownMenu
+						value={voiceOutput.voiceLang}
+						disabled={!this.TTSBrowserSupport}
+						onChange={this.handlePrefLang}>
+					 	{voiceOutput.voiceMenu}
+				 </DropDownMenu>
+				</div>
+             </div>
             {cookies.get('loggedIn') ?
               <div>
                 <div>

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,18 @@ import {
 	hashHistory
 } from 'react-router-dom';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
+// Internationalization
+
+import UserPreferencesStore from './stores/UserPreferencesStore';
+import {IntlProvider} from 'react-intl';
+import {addLocaleData} from 'react-intl';
+import en from 'react-intl/locale-data/en';
+import fr from 'react-intl/locale-data/fr';
+import es from 'react-intl/locale-data/es';
+import de from 'react-intl/locale-data/de';
+import ru from 'react-intl/locale-data/ru';
+
+addLocaleData([...en, ...fr, ...es,...de,...ru]);
 
 ChatWebAPIUtils.getSettings();
 ChatWebAPIUtils.getLocation();
@@ -36,6 +48,8 @@ const muiTheme = getMuiTheme({
   }
 });
 
+let defaults = UserPreferencesStore.getPreferences();
+let defaultPrefLanguage = defaults.PrefLanguage;
 const App = () => (
 	<Router history={hashHistory}>
 		<MuiThemeProvider muiTheme={muiTheme}>
@@ -65,6 +79,8 @@ window.speechSynthesis.onvoiceschanged = function () {
 };
 
 ReactDOM.render(
-	<App />,
+	<IntlProvider locale={defaultPrefLanguage}>
+	 	<App />
+	 </IntlProvider>,
 	document.getElementById('root')
 );

--- a/src/stores/UserPreferencesStore.js
+++ b/src/stores/UserPreferencesStore.js
@@ -16,6 +16,7 @@ let _defaults = {
     SpeechRate: 1,
     SpeechPitch: 1,
     TTSLanguage: 'en-US',
+    PrefLanguage : 'en-US'
 };
 
 let UserPreferencesStore = {
@@ -60,6 +61,9 @@ let UserPreferencesStore = {
     getTTSLanguage(){
       return _defaults.TTSLanguage;
     },
+    getPrefLang(){
+        return _defaults.PrefLanguage;
+    },
 
     addChangeListener(callback) {
         this.on(CHANGE_EVENT, callback);
@@ -101,6 +105,7 @@ UserPreferencesStore.dispatchToken = ChatAppDispatcher.register(action => {
                 _defaults.SpeechRate = settings.rate;
                 _defaults.SpeechPitch = settings.pitch;
                 _defaults.TTSLanguage = settings.lang;
+                _defaults.PrefLanguage = settings.PrefLanguage;
             }
             else{
                 if(settings.hasOwnProperty('theme')){
@@ -148,6 +153,10 @@ UserPreferencesStore.dispatchToken = ChatAppDispatcher.register(action => {
                 }
                 if(settings.hasOwnProperty('speech_lang')){
                   _defaults.TTSLanguage = settings.speech_lang;
+                }
+                if(settings.hasOwnProperty('pref_lang')){
+                    settings.PrefLanguage = settings.pref_lang;
+                  _defaults.PrefLanguage = settings.pref_lang;
                 }
             }
             UserPreferencesStore.emitChange();


### PR DESCRIPTION
Addresses issue #575

Changes: 
- Fetching local browser language and passing as props to the application.
- All Message `Time/Date and Dates` follow Internationalization based on formats in [https://formatjs.io]FormatJS)
- Added feature to send preferred language to the server and storing it in cookies as well for anonymous users.
Default value is  `PrefLang:en-US` 
- Translation for the Message section enabled, Messages shown and History will be rendered based on Preferred Language.



Demo Link - 
http://susi-international.surge.sh

Screenshots: 

Head over to `/settings` and select language from the `Language Settings` from the dropdown and change your preferred language to get responses from different languages and see all text in the preferred language.

Example for Italian
![screenshot from 2017-08-05 12 27 22](https://user-images.githubusercontent.com/11540785/28993663-a145c8b4-79d9-11e7-80cc-71e1ab85eddb.png)


`France Format`
![france](https://user-images.githubusercontent.com/11540785/28946556-f3b8cf9a-78c8-11e7-8d65-09d23796f42b.png)
`Russian Format`
![russian](https://user-images.githubusercontent.com/11540785/28946522-ca243426-78c8-11e7-804c-ae06a1757bd0.png)
`English(US) Format`
![eng](https://user-images.githubusercontent.com/11540785/28946685-7f58cb54-78c9-11e7-8c6b-84a04e2226ab.png)
`German Format`
![german](https://user-images.githubusercontent.com/11540785/28946694-85d95476-78c9-11e7-86b4-23f0a2cad12b.png)

