### PR TITLE
Fixes #657-Fix Dropdown menu structure and views across apps and pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react-leaflet": "^1.1.6",
     "react-linkify": "^0.2.1",
     "react-modal": "^2.2.2",
-    "react-progressive-image": "^0.1.2",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",
     "react-slick": "^0.14.11",

--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -108,6 +108,9 @@ class Login extends Component {
 	handleForgotPassword = () => {
 		this.props.handleForgotPassword();
 	}
+	handleSignUp = () => {
+		this.props.handleSignUp();
+	}
 	handleServeChange = (event) => {
         let state = this.state;
         let serverUrl
@@ -263,13 +266,25 @@ class Login extends Component {
 								disabled={!this.state.validForm}
 								style={{margin:'15px 0 '}}/>
 						</div>
-						<span className="forgotpwdlink"
+						<span
+						style={{
+							margin: '8px 0',
+							display:'block'
+						}}
+						className="forgotpwdlink"
 							onClick={this.handleForgotPassword}>
 								Forgot Password?
 						</span>
-						<br />
+						<div>
+							<RaisedButton
+									label='Sign Up'
+									onClick={this.handleSignUp}
+									backgroundColor={
+										UserPreferencesStore.getTheme()==='light' ? '#4285f4' : '#19314B'}
+									labelColor="#fff" />
+						</div>
 						<h4 style={{
-							margin: '7px 0'
+							margin: '2px 0'
 						}}>OR</h4>
 						<div>
 							<Link to={'/logout'} >
@@ -289,7 +304,8 @@ class Login extends Component {
 
 Login.propTypes = {
 	history: PropTypes.object,
-	handleForgotPassword: PropTypes.func
+	handleForgotPassword: PropTypes.func,
+	handleSignUp:PropTypes.func
 };
 
 

--- a/src/components/ChatApp/MessageSection/DialogSection.js
+++ b/src/components/ChatApp/MessageSection/DialogSection.js
@@ -35,7 +35,8 @@ export default class DialogSection extends Component {
           contentStyle={{width: '35%',minWidth: '300px'}}
           onRequestClose={this.props.onRequestClose()}>
           <Login {...this.props}
-          handleForgotPassword={this.props.onForgotPassword()}/>
+          handleForgotPassword={this.props.onForgotPassword()}
+          hadnleSignUp={this.props.handleSignUp}/>
           <Close style={closingStyle} onTouchTap={this.props.onRequestClose()} />
         </Dialog>
 
@@ -153,6 +154,7 @@ DialogSection.propTypes = {
     openHardwareChange: PropTypes.bool,
     openThemeChanger: PropTypes.bool,
     onLoginSignUp:PropTypes.func,
+    handleSignUp: PropTypes.func,
     ServerChangeActions: PropTypes.array,
     HardwareActions: PropTypes.array,
     customSettingsDone: PropTypes.object,

--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -833,6 +833,7 @@ class MessageSection extends Component {
               ThemeChangerComponents={components}
               bodyStyle={bodyStyle}
               actions={actions}
+              handleSignUp={this.handleSignUp}
               customSettingsDone={customSettingsDone}
               ServerChangeActions={serverDialogActions}
               HardwareActions={hardwareActions}

--- a/src/components/ChatApp/TopBar.react.js
+++ b/src/components/ChatApp/TopBar.react.js
@@ -16,7 +16,8 @@ import Exit from 'material-ui/svg-icons/action/exit-to-app';
 import Chat from 'material-ui/svg-icons/communication/chat';
 import SignUp from 'material-ui/svg-icons/action/account-circle';
 import Edit from 'material-ui/svg-icons/image/edit';
-import Lock from 'material-ui/svg-icons/action/lock-outline';
+import Info from 'material-ui/svg-icons/action/info';
+import Dashboard from 'material-ui/svg-icons/action/dashboard';
 
 const cookies = new Cookies();
 
@@ -82,23 +83,26 @@ class TopBar extends Component {
 					targetOrigin={{ horizontal: 'right', vertical: 'top' }}
 					onRequestClose={this.closeOptions}
 				>
+					<MenuItem primaryText="About"
+					containerElement={<Link to="/overview" />}
+					rightIcon={<Info/>}
+					/>
+					<MenuItem primaryText="Chat"
+						containerElement={<Link to="/" />}
+						rightIcon={<Chat/>}
+					/>
+					<MenuItem
+                    rightIcon={<Dashboard/>}
+                    href="http://skills.susi.ai"
+                    >Skills
+                    </MenuItem>
 					<MenuItem primaryText="Settings"
-						onClick={this.props.handleSettings}
+						containerElement={<Link to="/settings" />}
 						rightIcon={<Settings/>}/>
-					<MenuItem primaryText="Custom Theme"
+					<MenuItem primaryText="Themes"
 						key="custom"
 						onClick={this.props.handleThemeChanger}
 						rightIcon={<Edit/>}/>
-					<MenuItem primaryText="Change Password"
-						onTouchTap={this.props.handleChangePassword}
-						rightIcon={<Lock/>}/>
-					<MenuItem primaryText="Chat Anonymously"
-						containerElement={<Link to="/logout" />}
-						rightIcon={<Chat/>}
-					/>
-					<MenuItem primaryText="Overview"
-					containerElement={<Link to="/overview" />}
-					/>
 					<MenuItem primaryText="Logout"
 						containerElement={<Link to="/logout" />}
 						rightIcon={<Exit />}/>
@@ -126,17 +130,25 @@ class TopBar extends Component {
 					targetOrigin={{ horizontal: 'right', vertical: 'top' }}
 					onRequestClose={this.closeOptions}
 				>
-					<MenuItem primaryText="Settings"
-						onClick={this.props.handleSettings}
-						rightIcon={<Settings/>} />
-					<MenuItem primaryText="Overview"
+					<MenuItem primaryText="About"
 					containerElement={<Link to="/overview" />}
+					rightIcon={<Info/>}
 					/>
+					<MenuItem primaryText="Chat"
+					containerElement={<Link to="/" />}
+					rightIcon={<Chat/>}
+					/>
+					<MenuItem
+                    rightIcon={<Dashboard/>}
+                    href="http://skills.susi.ai"
+                    >Skills
+                    </MenuItem>
+					<MenuItem primaryText="Settings"
+						containerElement={<Link to="/settings" />}
+						rightIcon={<Settings/>} />
 					<MenuItem primaryText="Login"
-						onTouchTap={this.props.handleOpen} />
-					<MenuItem primaryText="Sign Up"
-						onTouchTap={this.props.handleSignUp}
-						rightIcon={<SignUp/>} />
+						onTouchTap={this.props.handleOpen}
+					rightIcon={<SignUp/>} />
 				</Popover>
 			</div>
 		)

--- a/src/components/Overview/Overview.react.js
+++ b/src/components/Overview/Overview.react.js
@@ -17,9 +17,6 @@ import PlayCircle from 'material-ui/svg-icons/av/play-circle-filled';
 import { Link } from 'react-router-dom';
 import Modal from 'react-modal';
 import Close from 'material-ui/svg-icons/navigation/close';
-import loading from '../../images/loading.gif';
-import ProgressiveImage from 'react-progressive-image';
-
 import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
 
 class Overview extends Component{
@@ -74,10 +71,7 @@ class Overview extends Component{
         <div className='section'>
           <div className='section-container'>
             <div className="hero">
-
-            <ProgressiveImage src={susiGif} placeholder={loading}>
-              {(src) => <img src={src} style={{ margin: '20px 0' }} alt='Meet SUSI'/>}
-            </ProgressiveImage>)
+              <img src={susiGif} style={{ margin: '20px 0' }} alt='Meet SUSI'/>
               <h1>Meet SUSI, Your Personal Assistant.</h1>
               <p>Ask it questions. Tell it to do things. Always ready to help.</p>
               <a onClick={this.handleVideo} style={{

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import susiWhite from '../../images/susi-logo-white.png';
 import PropTypes from 'prop-types';
-import Signup from 'material-ui/svg-icons/action/account-circle';
 import Drawer from 'material-ui/Drawer';
 import IconMenu from 'material-ui/IconMenu';
 import FlatButton from 'material-ui/FlatButton';
@@ -19,6 +18,10 @@ import Login from '../Auth/Login/Login.react';
 import Popover from 'material-ui/Popover';
 import ForgotPassword from '../Auth/ForgotPassword/ForgotPassword.react';
 import Cookies from 'universal-cookie';
+import Settings from 'material-ui/svg-icons/action/settings';
+import Info from 'material-ui/svg-icons/action/info';
+import SignUpIcon from 'material-ui/svg-icons/action/account-circle';
+import Dashboard from 'material-ui/svg-icons/action/dashboard';
 import Exit from 'material-ui/svg-icons/action/exit-to-app';
 
 
@@ -26,14 +29,31 @@ const cookies = new Cookies();
 
 let Logged = (props) => (
     <div>
-        <MenuItem primaryText="Login"
-            onTouchTap={this.handleLogin} />
-        <MenuItem primaryText="Sign Up"
-            onTouchTap={this.handleSignUp}
-            rightIcon={<Signup />} />
+        <MenuItem primaryText="About"
+        containerElement={<Link to="/overview" />}
+        rightIcon={<Info/>}
+        />
         <MenuItem primaryText="Chat"
-            containerElement={<Link to="/logout" />}
-            rightIcon={<Chat />} />
+        containerElement={<Link to="/" />}
+        rightIcon={<Chat/>}
+        />
+        <MenuItem
+        rightIcon={<Dashboard/>}
+        ><a
+        style={{
+            color: 'rgba(0, 0, 0, 0.87)',
+            width: '140px',
+            display:'block'
+        }}
+        href="http://skills.susi.ai">Skills</a>
+        </MenuItem>
+        <MenuItem primaryText="Settings"
+        containerElement={<Link to="/settings" />}
+        rightIcon={<Settings/>} />
+        <MenuItem
+        primaryText="Login"
+        onTouchTap={this.handleLogin}
+        rightIcon={<SignUpIcon/>} />
     </div>
 )
 class StaticAppBar extends Component {
@@ -158,23 +178,51 @@ class StaticAppBar extends Component {
             Logged = (props) => (
                 <div>
 
+                    <MenuItem primaryText="About"
+                    containerElement={<Link to="/overview" />}
+                    rightIcon={<Info/>}
+                    />
+                    <MenuItem primaryText="Chat"
+                        containerElement={<Link to="/" />}
+                        rightIcon={<Chat/>}
+                    />
+                    <MenuItem
+                    rightIcon={<Dashboard/>}
+                    href="http://skills.susi.ai"
+                    >Skills
+                    </MenuItem>
+                    <MenuItem primaryText="Settings"
+                    containerElement={<Link to="/settings" />}
+                    rightIcon={<Settings/>}/>
                     <MenuItem primaryText="Logout"
                         containerElement={<Link to="/logout" />}
-                        rightIcon={<Exit />} />
+                        rightIcon={<Exit />}/>
                 </div>
             )
             return <Logged />
         }
 Logged = (props) => (
     <div>
-        <MenuItem primaryText="Login"
-            onTouchTap={this.handleLogin} />
-        <MenuItem primaryText="Sign Up"
-            onTouchTap={this.handleSignUp}
-            rightIcon={<Signup />} />
+       <MenuItem primaryText="About"
+        containerElement={<Link to="/overview" />}
+        rightIcon={<Info/>}
+        />
         <MenuItem primaryText="Chat"
-            containerElement={<Link to="/logout" />}
-            rightIcon={<Exit />} />
+        containerElement={<Link to="/" />}
+        rightIcon={<Chat/>}
+        />
+        <MenuItem
+        rightIcon={<Dashboard/>}
+        href="http://skills.susi.ai"
+        >Skills
+        </MenuItem>
+        <MenuItem primaryText="Settings"
+        containerElement={<Link to="/settings" />}
+        rightIcon={<Settings/>} />
+        <MenuItem
+        primaryText="Login"
+        onTouchTap={this.handleLogin}
+        rightIcon={<SignUpIcon/>} />
     </div>
 )
 return <Logged />


### PR DESCRIPTION
Fixes issue #657 

Changes:
- [x] **Not logged in users:**
- About -> Overview
- Chat -> /chat app
- Skills -> / skills app
- Settings -> /settings
- Login -> login

- [x] **Logged in users:**
- About -> Overview
- Chat -> /chat app
- Skills -> / skills app
- Settings -> /settings
- [Themes -> theme popup (only in chat app)]
- Changed Password 
- Logout -> logout
- [x] Added Sign Up inside Login now
- [x] Add icons to all menu items
- [x] Don't show "signup" on menu. The link to signup on the login page is sufficient.
- [x] On chat app direct settings to chat app settings
- [x] On skills cms direct settings link to skills settings
- [x] Ensure the dropdown menu works on the same way on chat pages overview etc.

Demo Link:
http://susi-menu.surge.sh


Screenshots for the change: 
![screenshot from 2017-08-01 19 35 01](https://user-images.githubusercontent.com/11540785/28829663-29a27b0c-76f2-11e7-9f85-dc47d5b39167.png)

![screenshot from 2017-08-01 14 38 29](https://user-images.githubusercontent.com/11540785/28818111-d03f7968-76c7-11e7-93ea-c76af02a3f70.png)


`/settings` will be added in https://github.com/fossasia/chat.susi.ai/pull/625
