### PR TITLE
Fixes #668 - Improve text area overlap with send button

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -514,7 +514,6 @@ header{
   text-align: left;
   color: inherit;
   outline: 0;
-  min-width: 100%;
 }
 
 .dark .message-composer{
@@ -528,16 +527,30 @@ header{
   background: rgba(0, 0, 0, 0.01);
 }
 .textBack{
-  background: #fff;
-  width: 83%;
-  border-radius: 40px;
-  padding: 5px 20px;
-  display: block;
-  position: relative;
-  top: 12%;
-  box-sizing: content-box;
-  margin: 0px 0 10px 0;
+    background: #fff;
+    max-width: 89%;
+    border-radius: 10px;
+    display: block;
+    position: relative;
+    box-sizing: content-box;
+    line-height: 20px;
+    font-size: 15px;
+    min-height: 20px;
+    border: none;
+    padding: 10px 12px;
+    overflow-y: scroll;
+    max-height: 80px;
+}
+.textBack::-webkit-scrollbar {
+    width: 6px ;
+    height: 6px ;
+}
 
+.textBack::-webkit-scrollbar-thumb {
+    background-color: rgba(0,0,0,0.2);
+}
+.textBack::-webkit-scrollbar-track {
+    background: rgba(255,255,255,0.08);
 }
 textarea {
   border: none;
@@ -576,6 +589,9 @@ textarea {
 @media only screen and (min-width: 0px) and (max-width: 768px){
   textarea{
     width: 100%;
+  }
+  .textBack {
+    width: 81%;
   }
   .Modal{
     padding: 25px 0px 25px 0px;

--- a/src/components/ChatApp/MessageComposer.react.js
+++ b/src/components/ChatApp/MessageComposer.react.js
@@ -16,8 +16,8 @@ injectTapEventPlugin();
 let ENTER_KEY_CODE = 13;
 const style = {
   mini: true,
-  top: '10px',
-  right: '3px',
+  bottom: '11px',
+  right: '5px',
   position: 'absolute',
 };
 const iconStyles = {
@@ -209,7 +209,7 @@ class MessageComposer extends Component {
             onChange={this._onChange.bind(this)}
             onKeyDown={this._onKeyDown.bind(this)}
             ref={(textarea) => { this.nameInput = textarea; }}
-            style={{ background: this.props.textarea, ineHeight: '12px' }}
+            style={{ background: this.props.textarea, lineHeight: '15px' }}
           />
         </div>
         <IconButton


### PR DESCRIPTION
Fixes issue #668 

Changes: 
- Removed the text overlap with button
- Made the text-area close to WhatsApp


Demo Link: 
http://susi-textarea.surge.sh

Screenshots for the change: 
![localhost-3000- nexus 4](https://user-images.githubusercontent.com/11540785/28891230-6ff92df8-77e7-11e7-8e0d-d44193d7cc62.png)
![screenshot from 2017-08-03 01 10 37](https://user-images.githubusercontent.com/11540785/28891585-a1abc832-77e8-11e7-9c06-8c14a188a4e7.png)

