### PR TITLE
Fixes #537 - Make use of full width for map

### DIFF
--- a/src/components/ChatApp/MessageListItem/MessageListItem.react.js
+++ b/src/components/ChatApp/MessageListItem/MessageListItem.react.js
@@ -176,7 +176,7 @@ class MessageListItem extends React.Component {
                     mymap = drawMap(response.latitude,response.longitude,zoom);
                     listItems.push(
                       <li className='message-list-item' key={action+index}>
-                        <section className={messageContainerClasses}>
+                        <section className={messageContainerClasses} style={{'width' : '80%'}}>
                         <div className='message-text'>{replacedText}</div>
                         <br/>
                         <div>{mymap}</div>
@@ -196,7 +196,7 @@ class MessageListItem extends React.Component {
               }
               listItems.push(
                 <li className='message-list-item' key={action+index}>
-                  <section className={messageContainerClasses}>
+                  <section className={messageContainerClasses} style={{'width' : '80%'}}>
                   <div className='message-text'>{replacedText}</div>
                   <br/>
                   <div>{mymap}</div>


### PR DESCRIPTION
Fixes issue #537 

**Changes:**
 - Made map use full width irrespective of text content in chat bubble

**Demo Link:**  http://susimaps.surge.sh/

**Screenshots for the change:** 

![susimaps](https://user-images.githubusercontent.com/13276887/28952222-712370d8-78ed-11e7-9693-ac22c1aa44ca.png)
