### PR TITLE
Fixes #679 - Going to settings route shows Speech Settings disabled

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -81,9 +81,7 @@ class Settings extends Component {
 		let defaultSpeechPitch = defaults.SpeechPitch;
 		let defaultTTSLanguage = defaults.TTSLanguage;
 		let defaultPrefLanguage = defaults.PrefLanguage;
-    let voiceList = MessageStore.getTTSVoiceList();
-
-    let TTSBrowserSupport;
+    	let TTSBrowserSupport;
     if ('speechSynthesis' in window) {
       TTSBrowserSupport = true;
     } else {
@@ -133,7 +131,7 @@ class Settings extends Component {
 		};
 
     this.customServerMessage = '';
-    this.TTSBrowserSupport = TTSBrowserSupport && voiceList.length > 0;
+    this.TTSBrowserSupport = TTSBrowserSupport;
     this.STTBrowserSupport = STTBrowserSupport;
   }
 
@@ -392,11 +390,20 @@ class Settings extends Component {
 
 	componentWillMount() {
 		document.body.className = 'white-body';
-  }
+  	}
+  	componentWillUnmount() {
+    	MessageStore.removeChangeListener(this._onChange.bind(this));
+  	}
+  	_onChange() {
+  	  this.setState({
+  	  	voiceList: MessageStore.getTTSVoiceList()
+  	  });
+  	}
 
-	componentDidMount() {
+  	componentDidMount() {
+  		MessageStore.addChangeListener(this._onChange.bind(this));
 
-		this.setState({
+  		this.setState({
 	      search: false,
 	    });
 

--- a/src/stores/MessageStore.js
+++ b/src/stores/MessageStore.js
@@ -163,7 +163,6 @@ MessageStore.dispatchToken = ChatAppDispatcher.register(action => {
 
     case ActionTypes.CREATE_SUSI_MESSAGE: {
       let message = action.message;
-      console.log(message.lang);
       MessageStore.resetVoiceForThread(message.threadID);
       _messages[message.id] = message;
       _showLoading = false;


### PR DESCRIPTION
Fixes issue #679 

Changes: 
- Voice List being added once the component is being rendered in `/settings`
- Enabled all options for Speech after detecting the SpeechSynthesis.

Demo Link: 

http://susi-settings.surge.sh/settings


