### PR TITLE
Fixes #695 - /settings not working, set defaults in the settings even for localStorage

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -246,6 +246,22 @@ export function getSettings(){
     if(settings!==undefined){
       // Check if the settings are set in the cookie
       SettingsActions.initialiseSettings(settings);
+    }else{
+     // get defaults and set it in cookies
+      settings = UserPreferencesStore.getPreferences();
+      settings.theme = settings.Theme
+      settings.enterAsSend = settings.EnterAsSend
+      settings.micInput = settings.MicInput
+      settings.speechOutput = settings.SpeechOutput
+      settings.speechOutputAlways = settings.SpeechOutputAlways
+      settings.speechRate = settings.SpeechRate
+      settings.speechPitch = settings.SpeechPitch
+      settings.ttsLanguage = settings.TTSLanguage
+      settings.prefLanguage = settings.PrefLanguage
+      settings.customThemeValue = settings.ThemeValues
+      settings.LocalStorage = true;
+      cookies.set('settings',settings);
+      SettingsActions.initialiseSettings(settings);
     }
   }
   else{


### PR DESCRIPTION
Fixes issue #695 

Changes: 
- Handled the case where the user is anonymous and settings are initialized from cookies, where the values of cookies were not set.
- Now, `/settings` would work as all values are set by defaults.

Steps to test -
- Make sure to delete any previous cookies
- Go to Application in Dev Console in anonymous mode and check if the `settings` key is set as shown in the image. 

Demo link -
http://susi-cookies.surge.sh

Screenshots for the change: 
![screenshot from 2017-08-07 23 33 21](https://user-images.githubusercontent.com/11540785/29039533-428ba50e-7bc9-11e7-9a31-c5ff9ffca56f.png)

