### PR TITLE
fixes #748 reduce space between store icons for smaller screens

### DIFF
--- a/src/components/Overview/Overview.css
+++ b/src/components/Overview/Overview.css
@@ -571,7 +571,6 @@ header {
         display: block;
         float: none;
         margin: 0 auto 10px auto;
-        height: 100px;
         max-width: 100%;
         width: 50%;
         background-size: contain;
@@ -580,7 +579,6 @@ header {
         display: block;
         float: none;
         margin: 0 auto 10px auto;
-        height: 100px;
         max-width: 100%;
         width: 50%;
         background-size: contain;


### PR DESCRIPTION
Fixes issue #748 

Changes: Reduced space between store icons for smaller screens

Demo Link: http://susimadhav.surge.sh/overview

Screenshots for the change: 
![fix](https://user-images.githubusercontent.com/22375731/29524686-1f9f53de-86ae-11e7-94fb-9d20f7a5366f.png)
@rishiraj824 @uday96 @isuruAb Please Review
Thanks