### PR TITLE
Fixes #752 - Align contents of settings page

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -763,7 +763,8 @@ em{
 }
 
 .settings-toggle {
-  max-width: 60%;
+  margin: auto;
+  max-width: 30%;
   margin-top: 30px;
 }
 

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -70,8 +70,8 @@ class Settings extends Component {
 			speechOutputAlways: defaultSpeechOutputAlways,
 			server: defaultServer,
 			serverUrl: '',
-      		serverFieldError: false,
-      		checked: false,
+			serverFieldError: false,
+			checked: false,
 			validForm: true,
 			showLanguageSettings: false,
 			speechRate: defaultSpeechRate,
@@ -443,8 +443,9 @@ class Settings extends Component {
     	fontWeight: 400,
   		},
   		slide: {
-    		padding: 20
-  		},
+				textAlign: 'center',
+				padding: 20,
+			},
 		};
 
 		let serverSettingTab = <Tab


### PR DESCRIPTION
Fixes issue #752 

**Changes:**
 - Aligned contents of settings page to center

**Demo Link:**  http://susisettings.surge.sh/settings

**Screenshots for the change:** 

![setal](https://user-images.githubusercontent.com/13276887/29584926-eae0e77a-87a2-11e7-86a6-644c17286afe.png)

