### PR TITLE
Fixes #754 - Prevent card text overflow in firefox

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -682,9 +682,34 @@ textarea {
 .card-text{
   margin-top: -35px;
   overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+}
+
+.line-clamp {
+      position: relative;
+      height: 2.4em; /* exactly two lines */
+    }
+.line-clamp:after {
+      content: "...";
+      text-align: right;
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      width: 70%;
+      height: 1.2em;
+      background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 85%);
+ }
+
+@supports (-webkit-line-clamp: 2) {
+    .line-clamp {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        max-height:2.4em;
+        height: auto;
+    }
+    .line-clamp:after {
+        display: none;
+    }
 }
 
 .card-url{

--- a/src/components/ChatApp/MessageListItem/helperFunctions.react.js
+++ b/src/components/ChatApp/MessageListItem/helperFunctions.react.js
@@ -191,7 +191,7 @@ export function drawCards(tilesData){
           }
           <CardTitle title={tile.title} titleStyle={titleStyle}/>
           <CardText>
-            <div className='card-text'>{cardText}</div>
+            <div className='card-text line-clamp'>{cardText}</div>
             <div className='card-url'>{urlDomain(tile.link)}</div>
           </CardText>
         </Card>


### PR DESCRIPTION
Fixes issue #754 

**Changes:**
 - Since other browsers do not support webkit clamp, used css to show a fadeout for multi line overflow in firefox.

**Demo Link:**  http://styleswipe.surge.sh/

**Screenshots for the change:** 

![ov](https://user-images.githubusercontent.com/13276887/29586115-3ba72224-87a7-11e7-8358-46bd482c6ce2.png)
