### PR TITLE
Fixes #771 - Remove decoration for abbr and fix top bar pop over direction

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -853,7 +853,12 @@ em{
 .search{
   -webkit-text-fill-color: white;
   color: white;
-  ;
+}
+
+abbr[title] {
+  border-bottom: none;
+  cursor: inherit;
+  text-decoration: none;
 }
 
 .tile-title strong span{

--- a/src/components/ChatApp/TopBar.react.js
+++ b/src/components/ChatApp/TopBar.react.js
@@ -76,7 +76,7 @@ class TopBar extends Component {
 				</IconButton>
 				<Popover
 					{...props}
-					style={{marginLeft:'-35px'}}
+					style={{marginLeft:'-25px'}}
 					open={this.state.showOptions}
 					anchorEl={this.state.anchorEl}
 					anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
@@ -123,7 +123,7 @@ class TopBar extends Component {
 				</IconButton>
 				<Popover
 					{...props}
-					style={{marginLeft:'-35px'}}
+					style={{marginLeft:'-25px'}}
 					open={this.state.showOptions}
 					anchorEl={this.state.anchorEl}
 					anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -274,8 +274,8 @@ class StaticAppBar extends Component {
                         style={{ float: 'left', position: 'relative', marginTop: '46px', marginLeft: leftGap }}
                         open={this.state.showOptions}
                         anchorEl={this.state.anchorEl}
-                        anchorOrigin={{ horizontal: 'left', vertical: 'top' }}
-                        targetOrigin={{ horizontal: 'left', vertical: 'top' }}
+                        anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
+                        targetOrigin={{ horizontal: 'right', vertical: 'top' }}
                         onRequestClose={this.closeOptions}
                     >
                         <Logged />


### PR DESCRIPTION
Fixes issue #771 

**Changes:**
 - Removed text decoration for table entries caused due to abbr tag
 - Fixed top bar drop down direction on static pages similar to landing chat page

**Demo Link:** http://topbar.surge.sh/

**Screenshots for the change:** 

![tfix](https://user-images.githubusercontent.com/13276887/29742450-1d267d38-8a9d-11e7-9302-8d0c7c2d1aed.png)
