### PR TITLE
Add more enhancements to settings page #796

### DIFF
--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -3,6 +3,13 @@
   height: 100vh;
     background:  rgb(242, 242, 242);
 }
+
+.settings-list{
+    padding: 0px 0px;
+    user-select: none;
+    width: 100%;
+}
+
 .siteTitle {
     height: 25px;
     margin-top: 21px;
@@ -29,6 +36,10 @@
       margin-left: 30px;
 }
 
+.setting-item{
+  width: 97%;
+}
+
 .settingMenu {
 
     max-width: none;
@@ -53,12 +64,12 @@
 }
 
 .leftMenu {
-  width: 30%;
+  width: 35%;
   background-color: #fff;
 }
 
 .rightMenu {
-  width: 68%;
+  width: 64%;
    background-color: #fff;
 }
 
@@ -68,6 +79,12 @@
   height: 1px ;
   border: 0 none ;
   background-color : rgb(242, 242, 242) ;
+}
+
+.right-cheveron{
+  margin-top: 10px;
+  position: absolute;
+  right: 10px;
 }
 
 @media only screen and (max-width: 940px){
@@ -81,4 +98,8 @@
   .rightMenu {
     width: 100%;
   }
+
+  .setting-item{
+  width: 100%;
+}
 }

--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -81,7 +81,7 @@
   background-color : rgb(242, 242, 242) ;
 }
 
-.right-cheveron{
+.right-chevron{
   margin-top: 10px;
   position: absolute;
   right: 10px;

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -27,6 +27,7 @@ import Paper from 'material-ui/Paper';
 import ChatIcon from 'material-ui/svg-icons/communication/chat';
 import ThemeIcon from 'material-ui/svg-icons/action/invert-colors';
 import VoiceIcon from 'material-ui/svg-icons/action/settings-voice';
+import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
 import SpeechIcon from 'material-ui/svg-icons/action/record-voice-over';
 import AccountIcon from 'material-ui/svg-icons/action/account-box';
 import LanguageIcon from 'material-ui/svg-icons/action/language';
@@ -563,7 +564,7 @@ class Settings extends Component {
 						name="Theme"
 						defaultSelected={this.state.theme}>
 						<RadioButton
-									style={{width: '20%', display: 'inline-block'}}
+									style={{width: '20%', display: 'block'}}
 							value='light'
 							label={<Translate text="Light" />}
 						/>
@@ -702,29 +703,6 @@ class Settings extends Component {
 						'marginBottom':'0px',
 						fontSize: '15px',
 						fontWeight: 'bold'}}>
-						<Translate text="Select Theme"/>
-					</div>
-					<RadioButtonGroup
-						style={{textAlign: 'center', margin: 20}}
-						onChange={this.handleSelectChange}
-						name="Theme"
-						defaultSelected={this.state.theme}>
-						<RadioButton
-									style={{width: '20%', display: 'block'}}
-							value='light'
-							label={<Translate text="Light" />}
-						/>
-						<RadioButton
-									style={{width: '20%', display: 'block'}}
-							value='dark'
-							label={<Translate text="Dark" />}
-						/>
-					</RadioButtonGroup>
-					<div style={{
-						marginTop: '10px',
-						'marginBottom':'0px',
-						fontSize: '15px',
-						fontWeight: 'bold'}}>
 						<Translate text="Preferences"/>
 					</div>
 					<Toggle
@@ -736,47 +714,43 @@ class Settings extends Component {
 		}
 
 		let menuItems = cookies.get('loggedIn')?
-			<Menu
-				style={{margin: 'auto', width: '100%', }}
+			<Menu className="settings-list"
 				onItemTouchTap={this.loadSettings}
 				>
-
-					<MenuItem leftIcon={<ChatIcon/>}>ChatApp Settings</MenuItem>
-					<hr className="break-line"/>
-					<MenuItem leftIcon={<ThemeIcon/>}>Theme</MenuItem>
-					<hr className="break-line"/>
-					<MenuItem leftIcon={<VoiceIcon/>}>Mic Settings</MenuItem>
-					<hr className="break-line"/>
-					<MenuItem leftIcon={<SpeechIcon/>}>Speech Settings</MenuItem>
-					<hr className="break-line"/>
-					<MenuItem leftIcon={<LanguageIcon/>}>Text Language Settings</MenuItem>
-					<hr className="break-line"/>
-					<MenuItem leftIcon={<ServerIcon/>}>Server Settings</MenuItem>
-					<hr className="break-line"/>
-					<MenuItem leftIcon={<HardwareIcon/>}>Connect to SUSI Hardware</MenuItem>
-					<hr className="break-line"/>
-					<MenuItem leftIcon={<AccountIcon/>}>Account Settings</MenuItem>
-					<hr className="break-line"/>
+				<MenuItem className="setting-item" leftIcon={<ChatIcon/>}>ChatApp Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<hr className="break-line"/>
+				<MenuItem className="setting-item" leftIcon={<ThemeIcon/>}>Theme <ChevronRight className="right-cheveron"/></MenuItem>
+				<hr className="break-line"/>
+				<MenuItem className="setting-item" leftIcon={<VoiceIcon/>}>Mic Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<hr className="break-line"/>
+				<MenuItem className="setting-item" leftIcon={<SpeechIcon/>}>Speech Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<hr className="break-line"/>
+				<MenuItem className="setting-item" leftIcon={<LanguageIcon/>}>Text Language Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<hr className="break-line"/>
+				<MenuItem className="setting-item" leftIcon={<ServerIcon/>}>Server Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<hr className="break-line"/>
+				<MenuItem className="setting-item"  leftIcon={<HardwareIcon/>}>Connect to SUSI Hardware <ChevronRight className="right-cheveron"/></MenuItem>
+				<hr className="break-line"/>
+				<MenuItem className="setting-item" leftIcon={<AccountIcon/>}>Account Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<hr className="break-line"/>
 			</Menu>
 		:
-		<Menu className="settings-list-item"
-			style={{ width: '85%', margin: 'auto' }}
+		<Menu className="settings-list"
 			onItemTouchTap={this.loadSettings}
-			selectedMenuItemStyle={{width: '100%'}}
 			>
-				<MenuItem leftIcon={<ChatIcon/>}>ChatApp Settings</MenuItem>
+				<MenuItem className="setting-item" leftIcon={<ChatIcon/>}>ChatApp Settings <ChevronRight className="right-cheveron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem leftIcon={<ThemeIcon/>}>Theme</MenuItem>
+				<MenuItem className="setting-item" leftIcon={<ThemeIcon/>}>Theme <ChevronRight className="right-cheveron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem leftIcon={<VoiceIcon/>}>Mic Settings</MenuItem>
+				<MenuItem className="setting-item" leftIcon={<VoiceIcon/>}>Mic Settings <ChevronRight className="right-cheveron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem leftIcon={<SpeechIcon/>}>Speech Settings</MenuItem>
+				<MenuItem className="setting-item" leftIcon={<SpeechIcon/>}>Speech Settings <ChevronRight className="right-cheveron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem leftIcon={<LanguageIcon/>}>Text Language Settings</MenuItem>
+				<MenuItem className="setting-item" leftIcon={<LanguageIcon/>}>Text Language Settings <ChevronRight className="right-cheveron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem leftIcon={<ServerIcon/>}>Server Settings</MenuItem>
+				<MenuItem className="setting-item" leftIcon={<ServerIcon/>}>Server Settings <ChevronRight className="right-cheveron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem leftIcon={<HardwareIcon/>}>Connect to SUSI Hardware</MenuItem>
+				<MenuItem className="setting-item"  leftIcon={<HardwareIcon/>}>Connect to SUSI Hardware <ChevronRight className="right-cheveron"/></MenuItem>
 				<hr className="break-line"/>
 		</Menu>
 

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -423,7 +423,8 @@ class Settings extends Component {
 	}
 
 	loadSettings = (e) => {
-		this.setState({selectedSetting: e.target.innerText})
+		this.setState({selectedSetting: e.target.innerText});
+		this.setState({settingNo: e.target.innerText});
 	}
 
 	render() {
@@ -712,45 +713,49 @@ class Settings extends Component {
 						toggled={this.state.enterAsSend}/>
 				</div>);
 		}
-
+		let blueThemeColor={color: 'rgb(66, 133, 244)'};
 		let menuItems = cookies.get('loggedIn')?
 			<Menu className="settings-list"
 				onItemTouchTap={this.loadSettings}
+				selectedMenuItemStyle={blueThemeColor}
+				value={this.state.selectedSetting}
 				>
-				<MenuItem className="setting-item" leftIcon={<ChatIcon/>}>ChatApp Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='ChatApp Settings' className="setting-item" leftIcon={<ChatIcon/>}>ChatApp Settings<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem className="setting-item" leftIcon={<ThemeIcon/>}>Theme <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='Theme' className="setting-item" leftIcon={<ThemeIcon/>}>Theme<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem className="setting-item" leftIcon={<VoiceIcon/>}>Mic Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='Mic Settings' className="setting-item" leftIcon={<VoiceIcon/>}>Mic Settings<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem className="setting-item" leftIcon={<SpeechIcon/>}>Speech Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='Speech Settings' className="setting-item" leftIcon={<SpeechIcon/>}>Speech Settings<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem className="setting-item" leftIcon={<LanguageIcon/>}>Text Language Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='Text Language Settings' className="setting-item" leftIcon={<LanguageIcon/>}>Text Language Settings<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem className="setting-item" leftIcon={<ServerIcon/>}>Server Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='Server Settings' className="setting-item" leftIcon={<ServerIcon/>}>Server Settings<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem className="setting-item"  leftIcon={<HardwareIcon/>}>Connect to SUSI Hardware <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='Connect to SUSI Hardware' className="setting-item"  leftIcon={<HardwareIcon/>}>Connect to SUSI Hardware<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem className="setting-item" leftIcon={<AccountIcon/>}>Account Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='Account Settings' className="setting-item" leftIcon={<AccountIcon/>}>Account Settings<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
 			</Menu>
 		:
 		<Menu className="settings-list"
 			onItemTouchTap={this.loadSettings}
+			selectedMenuItemStyle={{color: 'rgb(66, 133, 244)'}}
+			value={this.state.selectedSetting}
 			>
-				<MenuItem className="setting-item" leftIcon={<ChatIcon/>}>ChatApp Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='ChatApp Settings' className="setting-item" leftIcon={<ChatIcon/>}>ChatApp Settings<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem className="setting-item" leftIcon={<ThemeIcon/>}>Theme <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='Theme' className="setting-item" leftIcon={<ThemeIcon/>}>Theme<ChevronRight className="right-cheveron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem className="setting-item" leftIcon={<VoiceIcon/>}>Mic Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='Mic Settings' className="setting-item" leftIcon={<VoiceIcon/>}>Mic Settings<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem className="setting-item" leftIcon={<SpeechIcon/>}>Speech Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='Speech Settings' className="setting-item" leftIcon={<SpeechIcon/>}>Speech Settings<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem className="setting-item" leftIcon={<LanguageIcon/>}>Text Language Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='Text Language Settings' className="setting-item" leftIcon={<LanguageIcon/>}>Text Language Settings<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem className="setting-item" leftIcon={<ServerIcon/>}>Server Settings <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='Server Settings' className="setting-item" leftIcon={<ServerIcon/>}>Server Settings<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
-				<MenuItem className="setting-item"  leftIcon={<HardwareIcon/>}>Connect to SUSI Hardware <ChevronRight className="right-cheveron"/></MenuItem>
+				<MenuItem value='Connect to SUSI Hardware' className="setting-item"  leftIcon={<HardwareIcon/>}>Connect to SUSI Hardware<ChevronRight className="right-chevron"/></MenuItem>
 				<hr className="break-line"/>
 		</Menu>
 


### PR DESCRIPTION
Further enhancements for issue #796 
Changes: 
-Added Chevron in settings list like twitter
-Fixed the bug in theme selection(was displayed at two tabs)
-Fixed the overflow of div on hover in Logged In state

Demo Link: http://horrible-cakes.surge.sh/

Screenshots for the change: 
![screen shot 2017-09-20 at 11 17 25 am](https://user-images.githubusercontent.com/11137394/30628687-6453fb20-9df5-11e7-8e15-03f7aebb1359.png)


