### PR TITLE
Fixes issue #809 - Enable click on the toggle label in Login popup

### DIFF
--- a/src/components/ChatApp/CustomServer.react.js
+++ b/src/components/ChatApp/CustomServer.react.js
@@ -31,6 +31,9 @@ export default class CustomServer extends Component {
         const underlineFocusStyle= {
             color: '#4285f4'
         }
+        const ToggleLableStyle={
+          zIndex:this.props.checked?3:0
+        }
         const serverURL = <TextField
                             name="serverUrl"
                             className="serverUrl"
@@ -50,7 +53,7 @@ export default class CustomServer extends Component {
                     <Toggle
                         labelPosition="right"
                         id={'uniqueId'}
-                        labelStyle={{ zIndex: 3 }}
+                        labelStyle={ToggleLableStyle}
                         label={this.props.checked?(
                                 <label htmlFor={'uniqueId'}>
                                         <div>


### PR DESCRIPTION
Fixes issue #809 

Changes: Enable clicking on the text "Use Custom Server" in the Login popup to toggle the option.

Demo Link: [spectacular-writing.surge.sh](http://spectacular-writing.surge.sh/)

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/17807257/30611447-0b9248b2-9d9f-11e7-9b3b-b4db1a14d738.png)

