### PR TITLE
Fixes: #825 - changed colour of message send button 

### DIFF
--- a/src/components/ChatApp/MessageComposer.react.js
+++ b/src/components/ChatApp/MessageComposer.react.js
@@ -217,7 +217,7 @@ class MessageComposer extends Component {
         <IconButton
           className="send_button"
           iconStyle={{
-            fill: UserPreferencesStore.getTheme() === 'light' ? '#4285f4' : '#fff',
+          fill: UserPreferencesStore.getTheme() === 'dark' ?  '#fff' :  '#4285f4',
             margin: '1px 0px 1px 0px'
           }}
           onTouchTap={this._onClickButton.bind(this)}


### PR DESCRIPTION
Fixes issue #825 Colour of send button will turn white only if theme is dark. 
  
Demo link: http://rahul-singh.surge.sh/


Changes:After changing theme send button colour won't turn into white until changed theme is dark.
To see the work 
 1.   login
 2.   Select themes 
 3.   change  theme
 4.   check arrow
 In chat.susi.ai site arrow is white that is barely visible

In demo link its blue and clearly visible.

![sendbutton](https://user-images.githubusercontent.com/26675957/30786105-6cbbbb1c-a18e-11e7-9089-6380b23dfb3d.png)


S