### PR TITLE
Center-aligned the Custom Server element

### DIFF
--- a/src/components/ChatApp/CustomServer.react.js
+++ b/src/components/ChatApp/CustomServer.react.js
@@ -32,7 +32,8 @@ export default class CustomServer extends Component {
             color: '#4285f4'
         }
         const ToggleLableStyle={
-          zIndex:this.props.checked?3:0
+          zIndex:this.props.checked?3:0,
+          textAlign: 'center',
         }
         const serverURL = <TextField
                             name="serverUrl"
@@ -52,11 +53,11 @@ export default class CustomServer extends Component {
              <div>
                     <Toggle
                         labelPosition="right"
-                        id={'uniqueId'}
+                        id={'customServerID'}
                         labelStyle={ToggleLableStyle}
                         label={this.props.checked?(
-                                <label htmlFor={'uniqueId'}>
-                                        <div>
+                                <label htmlFor={'customServerID'}>
+                                        <div id="customServerID">
                                            {customServer}
                                         </div>
                                 </label>
@@ -64,11 +65,12 @@ export default class CustomServer extends Component {
                         toggled={this.props.checked}
                         onToggle={this.handleServeChange}
                         style={{display: 'flex',
-                            marginTop: '10px',
+                            marginTop: '25px',
+                            marginBottom: '10px',
                             maxWidth:'245px',
                             flexWrap: 'wrap',
                             height:'28px',
-                            margin: '20px auto 20px 30px'}}
+                        }}
                         value="customServer"
                     />
             </div>


### PR DESCRIPTION
Fixes issue #829  
Changes: The custom-server button has been center-aligned

Demo Link: near-shoe.surge.sh

Screenshots for the change: 
Before:
<img width="459" alt="30806380-3412d220-a213-11e7-9ebf-bb26e8d6c45c" src="https://user-images.githubusercontent.com/26062692/30832417-a75a064a-a268-11e7-9769-bfb9d1ab4b57.png">

After:
![screen shot 2017-09-26 at 3 11 03 am](https://user-images.githubusercontent.com/26062692/30832372-7bd792da-a268-11e7-9858-fe5970806e9c.png)

