### PR TITLE
Appearance improvements in SUSI Hardware Tab in Settings

### DIFF
--- a/src/components/Auth/Login/Login.css
+++ b/src/components/Auth/Login/Login.css
@@ -14,9 +14,9 @@
 	width: 256px;
 }
 .loginForm h3{
-	font-family: 'Open Sans', sans-serif;
+	font-family: 'Open Sans, sans-serif';
 	margin: 5px 0;
-	font-weight: 500;
+	font-weight: bold;
 }
 
 @media screen and (max-width: 768px) {

--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -68,7 +68,6 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#183850', end
   position: absolute;
   transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
 }
-
 .send_button{
   align-content: center;
   border-radius: 50%;

--- a/src/components/ChatApp/HardwareComponent.js
+++ b/src/components/ChatApp/HardwareComponent.js
@@ -64,19 +64,17 @@ class HardwareComponent extends Component {
   };
 
   render() {
-    const headerStyle = {
-      fontFamily: 'Open Sans',
-      margin: '5px 0',
-      fontWeight: '500'
-    }
     const styles = {
       'textAlign': 'center',
       'padding': '10px 0'
     }
+    const connectButtonDivStyle = {
+      'marginTop': '25px',
+    }
     return (
       <div className="loginForm">
         <Paper zDepth={0} style={styles}>
-          <h3 style={headerStyle}><Translate text="Enter Socket Web Address"/></h3>
+          <h3><Translate text="Enter Socket Web Address"/></h3>
           <form onSubmit={this.handleSubmit}>
           <div>
           <TextField name="serverUrl"
@@ -84,7 +82,7 @@ class HardwareComponent extends Component {
                   errorText={this.customServerMessage}
                   floatingLabelText={<Translate text="Websocket URL"/>} />
           </div>
-          <div>
+          <div style={connectButtonDivStyle}>
             <RaisedButton
               label={<Translate text="Connect"/>}
               type="submit"

--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -53,7 +53,6 @@
 .setting-item{
   width: 97%;
 }
-
 .settingMenu {
 
     max-width: none;

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -469,7 +469,9 @@ class Settings extends Component {
 	/>];
 
 		const Buttonstyles = {
-			marginBottom: '16px',
+			marginBottom: '15px',
+			marginTop: '15px',
+			marginLeft: '35px',
 		}
 
 		const divStyle = {
@@ -678,19 +680,20 @@ class Settings extends Component {
 			currentSetting = (
 				<span style={divStyle}>
 					<div>
-					<div style={{
-						marginTop: '10px',
-						'marginBottom':'0px',
-						marginLeft: '30px',
-						fontSize: '15px',
-						fontWeight: 'bold'}}>
-						<Translate text="Connect to SUSI Hardware"/>
-					</div>
-					<FlatButton
-						className='settingsBtns'
-						style={Buttonstyles}
-						label={<Translate text="Add address to connect to Hardware"/>}
-						onClick={this.handleHardware} />
+						<div style={{
+							marginTop: '10px',
+							'marginBottom':'0px',
+							marginLeft: '30px',
+							fontSize: '15px',
+							fontWeight: 'bold'}}>
+							<Translate text="Connect to SUSI Hardware"/>
+						</div>
+						<FlatButton
+							className='settingsBtns'
+							style={Buttonstyles}
+							id="hardwareBtn"
+							label={<Translate text="Add address to connect to Hardware"/>}
+							onClick={this.handleHardware} />
 					</div>
 				</span>
 			)


### PR DESCRIPTION
Fixes issue #830

Changes: 

1. The 'Add address to connect to hardware' button has been given some margin from the left.
2. The font has been changed to sans-serif from Open Sans in the title of the dialog box on clicking the button mentioned in 1.
3. The connect button has been given margin from the top.

Demo Link: classy-knife.surge.sh

Screenshots for the change: 
Before:
![screen shot 2017-09-26 at 1 22 09 am](https://user-images.githubusercontent.com/26062692/30869042-daab5572-a2fd-11e7-93d0-b3746bca9696.png)

![screen shot 2017-09-26 at 1 22 20 am](https://user-images.githubusercontent.com/26062692/30869081-ec2cd4ce-a2fd-11e7-80c6-0456d9206d9d.png)

After:
![screen shot 2017-09-26 at 9 00 27 pm](https://user-images.githubusercontent.com/26062692/30869145-144b350e-a2fe-11e7-906e-0b55e0974aba.png)
![screen shot 2017-09-26 at 9 00 19 pm](https://user-images.githubusercontent.com/26062692/30869164-1aba60f4-a2fe-11e7-96c0-09b6078f35d5.png)