### PR TITLE
Remove unnecessary api calls to gtranslate

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -118,26 +118,6 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
         // Setting Language received from User
         receivedMessage.lang = response.answers[0].actions[0].language;
       }
-      let defaultPrefLanguage = defaults.PrefLanguage;
-      // Translate the message text
-        let urlForTranslate = 'https://translate.googleapis.com/translate_a/single?client=gtx&sl=en-US&tl='+defaultPrefLanguage+'&dt=t&q='+receivedMessage.text;
-        $.ajax({
-          url: urlForTranslate,
-          dataType: 'json',
-          crossDomain: true,
-          timeout: 3000,
-          async: false,
-          success: function (data) {
-            if(data[0]){
-              if(data[0][0]){
-                receivedMessage.text = data[0][0][0];
-              }
-            }
-          },
-          error: function(errorThrown){
-            console.log(errorThrown);
-          }
-        });
       receivedMessage.response = response;
       let actions = [];
       response.answers[0].actions.forEach((actionobj) => {

--- a/src/actions/History.actions.js
+++ b/src/actions/History.actions.js
@@ -80,52 +80,11 @@ export function getHistory() {
         userMsg.date = new Date(cognition.query_date);
         userMsg.text = query;
 
-        // Translate history
-        let defaultPrefLanguage = defaults.PrefLanguage;
-        // Translate the User message text
-        let urlForTranslate = 'https://translate.googleapis.com/translate_a/single?client=gtx&sl=en-US&tl='+defaultPrefLanguage+'&dt=t&q='+userMsg.text;
-        $.ajax({
-          url: urlForTranslate,
-          dataType: 'json',
-          crossDomain: true,
-          timeout: 3000,
-          async: false,
-          success: function (response) {
-            if(response[0]){
-              if(response[0][0]){
-                userMsg.text = response[0][0][0];
-              }
-            }
-          },
-          error: function(errorThrown){
-            console.log(errorThrown);
-          }
-        });
-
         susiMsg.id = 'm_' + Date.parse(cognition.answer_date);
         susiMsg.date = new Date(cognition.answer_date);
         susiMsg.text = cognition.answers[0].actions[0].expression;
         susiMsg.response = cognition;
 
-        // Translate the SUSI message text
-        urlForTranslate = 'https://translate.googleapis.com/translate_a/single?client=gtx&sl=en-US&tl='+defaultPrefLanguage+'&dt=t&q='+susiMsg.text;
-        $.ajax({
-          url: urlForTranslate,
-          dataType: 'json',
-          crossDomain: true,
-          timeout: 3000,
-          async: false,
-          success: function (response) {
-            if(response[0]){
-              if(response[0][0]){
-                susiMsg.text = response[0][0][0];
-              }
-            }
-          },
-          error: function(errorThrown){
-            console.log(errorThrown);
-          }
-        });
         let actions = [];
         cognition.answers[0].actions.forEach((actionObj) => {
           actions.push(actionObj.type);


### PR DESCRIPTION
Fixes issue #838 

Changes: Removed multiple calls to google translate API on load of chat app.

Demo Link: http://neat-sack.surge.sh/ (updated)

Screenshots for the change: 
As the network tab shows, gtranslate only gets called when sending or receiving messages.

![gtranslate](https://user-images.githubusercontent.com/20766601/31090914-f2817ad2-a7c6-11e7-9b5f-78a19fea5fa3.png)

