### PR TITLE
Restructure Settings, enable dark theme - Fix #840

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -333,6 +333,11 @@ export function getSettings(){
       settings.prefLanguage = settings.PrefLanguage
       settings.customThemeValue = settings.ThemeValues
       settings.LocalStorage = true;
+      settings.checked=false;
+      settings.CountryCode= 'US';
+      settings.CountryDialCode='+1';
+      settings.phoneNo= '';
+      settings.serverUrl='https://api.susi.ai';
       cookies.set('settings',settings);
       SettingsActions.initialiseSettings(settings);
     }
@@ -365,6 +370,9 @@ export function getSettings(){
       timeout: 3000,
       async: false,
       success: function (response) {
+          if(response.hasOwnProperty('session') && response.accepted){
+            SettingsActions.initialiseIdentity(response.session.identity);
+          }
         if(response.hasOwnProperty('settings') && response.accepted){
           SettingsActions.initialiseSettings(response.settings);
         }

--- a/src/actions/Settings.actions.js
+++ b/src/actions/Settings.actions.js
@@ -26,6 +26,13 @@ export function initialiseSettings(settings) {
   });
 }
 
+export function initialiseIdentity(identity) {
+  ChatAppDispatcher.dispatch({
+    type: ActionTypes.INIT_IDENTITY,
+    identity
+  });
+}
+
 export function initialiseTTSVoices(voiceList) {
   ChatAppDispatcher.dispatch({
     type: ActionTypes.INIT_TTS_VOICES,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -17,6 +17,7 @@ import {  createMessage,
 
 import {  serverChanged,
           initialiseSettings,
+          initialiseIdentity,
           initialiseTTSVoices,
           settingsChanged,
           customThemeChanged,
@@ -44,10 +45,10 @@ export {  createMessage,
 
 export { serverChanged,
          initialiseSettings,
+         initialiseIdentity,
          initialiseTTSVoices,
          settingsChanged,
          customThemeChanged,
         }
 
 export { connectToWebSocket, sendToHardwareDevice }
-

--- a/src/components/Auth/ChangePassword/ChangePassword.css
+++ b/src/components/Auth/ChangePassword/ChangePassword.css
@@ -1,6 +1,6 @@
 .changePasswordForm{
 	margin: 0 auto;
-	padding: 15px 0;
+	padding:0;
 }
 .changePasswordForm h3{
 	font-family: 'Open Sans', sans-serif;

--- a/src/components/Auth/ChangePassword/ChangePassword.react.js
+++ b/src/components/Auth/ChangePassword/ChangePassword.react.js
@@ -85,7 +85,7 @@ export default class ChangePassword extends Component {
               let result = zxcvbn(newPassword);
               state.newPasswordScore = result.score;
               let strength = [
-                <Translate key={1} text="Worst" />,
+                <Translate key={1} text="Too Insecure" />,
                 <Translate key={2} text="Bad" />,
                 <Translate key={3} text="Weak" />,
                 <Translate key={4} text="Good" />,
@@ -234,11 +234,15 @@ export default class ChangePassword extends Component {
     }
 
     render() {
+        const themeBackgroundColor=(this.props.settings && this.props.settings.theme)==='dark'?'#19324c':'#fff';
+        const themeForegroundColor=(this.props.settings && this.props.settings.theme)==='dark'?'#fff':'#272727';
 
         const styles = {
             'width': '100%',
-            'textAlign': 'center',
-            'padding': '10px'
+            'textAlign': 'left',
+            'padding': '10px',
+            paddingTop:'0px',
+            backgroundColor:themeBackgroundColor
         }
         const closingStyle ={
           position: 'absolute',
@@ -251,18 +255,23 @@ export default class ChangePassword extends Component {
           cursor:'pointer'
         }
         const fieldStyle={
-            'width':'256px'
+            'width':'256px',
+            color:themeForegroundColor
+        }
+        const inputStyle={
+            color:themeForegroundColor
         }
         const underlineFocusStyle= {
             color: '#4285f4'
         }
-
+        const floatingLabelStyle={
+            color:'#9E9E9E'
+        }
         const PasswordClass=[`is-strength-${this.state.newPasswordScore}`];
 
         return (
             <div className="changePasswordForm">
                 <Paper zDepth={0} style={styles}>
-                    <h3><Translate text="Change Password" /></h3>
                     <form onSubmit={this.handleSubmit}>
                         <div>
                             <PasswordField
@@ -270,8 +279,11 @@ export default class ChangePassword extends Component {
                                 style={fieldStyle}
                                 value={this.state.passwordValue}
                                 onChange={this.handleChange}
+                                inputStyle={inputStyle}
                                 errorText={this.passwordErrorMessage}
                                 underlineFocusStyle={underlineFocusStyle}
+                                floatingLabelStyle={floatingLabelStyle}
+                                visibilityIconStyle={{color:themeForegroundColor}}
                                 floatingLabelFocusStyle={underlineFocusStyle}
                                 floatingLabelText={<Translate text="Current Password" />} />
                         </div>
@@ -281,6 +293,9 @@ export default class ChangePassword extends Component {
                                 style={fieldStyle}
                                 value={this.state.newPasswordValue}
                                 onChange={this.handleChange}
+                                inputStyle={inputStyle}
+                                floatingLabelStyle={floatingLabelStyle}
+                                visibilityIconStyle={{color:themeForegroundColor}}
                                 errorText={this.newPasswordErrorMessage}
                                 underlineFocusStyle={underlineFocusStyle}
                                 floatingLabelFocusStyle={underlineFocusStyle}
@@ -298,6 +313,9 @@ export default class ChangePassword extends Component {
                                 style={fieldStyle}
                                 value={this.state.confirmNewPasswordValue}
                                 onChange={this.handleChange}
+                                inputStyle={inputStyle}
+                                floatingLabelStyle={floatingLabelStyle}
+                                visibilityIconStyle={{color:themeForegroundColor}}
                                 errorText={this.newPasswordConfirmErrorMessage}
                                 underlineFocusStyle={underlineFocusStyle}
                                 floatingLabelFocusStyle={underlineFocusStyle}
@@ -308,9 +326,7 @@ export default class ChangePassword extends Component {
                                 label={<Translate text="Change" />}
                                 type="submit"
                                 disabled={!this.state.validForm}
-                                backgroundColor={
-                                    UserPreferencesStore.getTheme()==='light'
-                                    ? '#4285f4' : '#19314B'}
+                                backgroundColor='#4285f4'
                                 labelColor="#fff" />
                         </div>
                     </form>
@@ -331,5 +347,6 @@ export default class ChangePassword extends Component {
 }
 
 ChangePassword.propTypes = {
-    history: PropTypes.object
+    history: PropTypes.object,
+    settings: PropTypes.object
 }

--- a/src/components/ChatApp/CustomServer.react.js
+++ b/src/components/ChatApp/CustomServer.react.js
@@ -22,7 +22,14 @@ export default class CustomServer extends Component {
     }
 
     render(){
+		const themeForegroundColor=this.props.settings && this.props.settings.theme==='dark'?'#fff':'#272727';
 
+		const floatingLabelStyle={
+			color:'#9e9e9e'
+		}
+        const inputStyle={
+            color:themeForegroundColor
+        }
         const customUrlStyle = {
             width:'175px',
             textAlign:'left',
@@ -34,6 +41,7 @@ export default class CustomServer extends Component {
         const ToggleLableStyle={
           zIndex:this.props.checked?3:0,
           textAlign: 'center',
+          color:themeForegroundColor
         }
         const serverURL = <TextField
                             name="serverUrl"
@@ -42,6 +50,8 @@ export default class CustomServer extends Component {
                             floatingLabelFocusStyle={underlineFocusStyle}
                             onChange={this.handleServeChange}
                             onTouchTap={this.handleServeChange}
+                            inputStyle={inputStyle}
+                            floatingLabelStyle={floatingLabelStyle}
                             value={this.props.serverUrl}
                             errorText={this.props.customServerMessage}
                             floatingLabelText={<Translate text="Custom URL"/>}
@@ -83,4 +93,5 @@ CustomServer.propTypes = {
     serverUrl: PropTypes.string,
     customServerMessage: PropTypes.string,
     onServerChange: PropTypes.func,
+    settings:PropTypes.object
 }

--- a/src/components/ChatApp/HardwareComponent.js
+++ b/src/components/ChatApp/HardwareComponent.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import TextField from 'material-ui/TextField';
 import Paper from 'material-ui/Paper';
 import * as Actions from '../../actions/';
-import UserPreferencesStore from '../../stores/UserPreferencesStore';
 import Translate from '../Translate/Translate.react';
 
 class HardwareComponent extends Component {
@@ -15,7 +14,7 @@ class HardwareComponent extends Component {
       serverUrl: '',
       serverFieldError: false,
       checked: false,
-      validForm: true,
+      validForm: false,
       open: false
     };
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -54,7 +53,7 @@ class HardwareComponent extends Component {
       this.customServerMessage = '';
     }
 
-    if (!state.serverFieldError || !state.checked) {
+    if (!state.serverFieldError) {
       state.validForm = true;
     }
     else {
@@ -64,21 +63,38 @@ class HardwareComponent extends Component {
   };
 
   render() {
+    const themeBackgroundColor=(this.props.settings && this.props.settings.theme)==='dark'?'#19324c':'#fff';
+    const themeForegroundColor=(this.props.settings && this.props.settings.theme)==='dark'?'#fff':'#272727';
+    const floatingLabelStyle={
+            color:'#9E9E9E'
+    }
     const styles = {
-      'textAlign': 'center',
-      'padding': '10px 0'
+      'textAlign': 'left',
+      'padding': '10px',
+      paddingTop:'0px',
+      paddingLeft: '30px',
+      backgroundColor:themeBackgroundColor
+    }
+    const inputStyle={
+            color:themeForegroundColor
+    }
+    const underlineFocusStyle= {
+            color: '#4285f4'
     }
     const connectButtonDivStyle = {
       'marginTop': '25px',
     }
+
     return (
-      <div className="loginForm">
+      <div className="loginForm" style={{paddingTop:'0px'}}>
         <Paper zDepth={0} style={styles}>
-          <h3><Translate text="Enter Socket Web Address"/></h3>
           <form onSubmit={this.handleSubmit}>
           <div>
           <TextField name="serverUrl"
                   onChange={this.handleChange}
+                  inputStyle={inputStyle}
+                  floatingLabelStyle={floatingLabelStyle}
+                  floatingLabelFocusStyle={underlineFocusStyle}
                   errorText={this.customServerMessage}
                   floatingLabelText={<Translate text="Websocket URL"/>} />
           </div>
@@ -87,8 +103,7 @@ class HardwareComponent extends Component {
               label={<Translate text="Connect"/>}
               type="submit"
               disabled={!this.state.validForm}
-              backgroundColor={
-                UserPreferencesStore.getTheme()==='light' ? '#4285f4' : '#19314B'}
+              backgroundColor='#4285f4'
               labelColor="#fff"
             />
           </div>
@@ -99,7 +114,8 @@ class HardwareComponent extends Component {
 }
 
 HardwareComponent.propTypes = {
-  history: PropTypes.object
+  history: PropTypes.object,
+  settings:PropTypes.object
 };
 
 export default HardwareComponent;

--- a/src/components/ChatApp/MessageComposer.react.js
+++ b/src/components/ChatApp/MessageComposer.react.js
@@ -361,7 +361,7 @@ MessageComposer.propTypes = {
   textarea: PropTypes.string,
   speechOutput: PropTypes.bool,
   speechOutputAlways: PropTypes.bool,
-  micColor: PropTypes.string.isRequired,
+  micColor: PropTypes.string,
 };
 
 export default MessageComposer;

--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -100,6 +100,10 @@
   right: 10px;
 }
 
+.email-field:hover{
+    cursor: not-allowed;
+}
+
 
 @media only screen and (max-width: 1000px){
   .settings-list-dropdown{

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -5,6 +5,7 @@ import DropDownMenu from 'material-ui/DropDownMenu';
 import MenuItem from 'material-ui/MenuItem';
 import PropTypes from 'prop-types';
 import UserPreferencesStore from '../../../stores/UserPreferencesStore';
+import UserIdentityStore from '../../../stores/UserIdentityStore';
 import MessageStore from '../../../stores/MessageStore';
 import Cookies from 'universal-cookie';
 import Toggle from 'material-ui/Toggle';
@@ -32,6 +33,7 @@ import VoiceIcon from 'material-ui/svg-icons/action/settings-voice';
 import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
 import SpeechIcon from 'material-ui/svg-icons/action/record-voice-over';
 import AccountIcon from 'material-ui/svg-icons/action/account-box';
+import LockIcon from 'material-ui/svg-icons/action/lock';
 import LanguageIcon from 'material-ui/svg-icons/action/language';
 import ServerIcon from 'material-ui/svg-icons/file/cloud';
 import HardwareIcon from 'material-ui/svg-icons/hardware/memory';
@@ -44,7 +46,7 @@ class Settings extends Component {
 	// save a variable in state holding the initial state of the settings
 	setInitialSettings = () => {
 		let defaults = UserPreferencesStore.getPreferences();
-		console.log('default',defaults);
+		let identity = UserIdentityStore.getIdentity();
 		let defaultServer = defaults.Server;
 		let defaultTheme = defaults.Theme;
 		let defaultEnterAsSend = defaults.EnterAsSend;
@@ -54,11 +56,14 @@ class Settings extends Component {
 		let defaultSpeechRate = defaults.SpeechRate;
 		let defaultSpeechPitch = defaults.SpeechPitch;
 		let defaultPrefLanguage = defaults.PrefLanguage;
+		let defaultChecked = defaults.checked;
+		let defaultServerUrl= defaults.serverUrl;
 		let defaultCountryCode = defaults.CountryCode;
 		let defaultCountryDialCode = defaults.CountryDialCode;
-		let defaultPhoneNo = defaults.PhoneNo;
+		let defaultPhoneNo = defaults.phoneNo;
 		this.setState({
-			intialSettings: {
+			identity,
+			intialSettings:{
 				theme: defaultTheme,
 				enterAsSend: defaultEnterAsSend,
 				micInput: defaultMicInput,
@@ -67,61 +72,63 @@ class Settings extends Component {
 				speechRate: defaultSpeechRate,
 				speechPitch: defaultSpeechPitch,
 				server: defaultServer,
-				serverUrl: '',
-				checked: false,
 				PrefLanguage: defaultPrefLanguage,
+				serverUrl: defaultServerUrl,
+				checked: defaultChecked,
 				countryCode: defaultCountryCode,
 				countryDialCode: defaultCountryDialCode,
 				phoneNo: defaultPhoneNo
 			}
 		})
 	}
+	// extract values from store to get the initial settings
 	setDefaultsSettings = () => {
-		let defaults = UserPreferencesStore.getPreferences();
-		let defaultServer = defaults.Server;
-		let defaultTheme = defaults.Theme;
-		let defaultEnterAsSend = defaults.EnterAsSend;
-		let defaultMicInput = defaults.MicInput;
-		let defaultSpeechOutput = defaults.SpeechOutput;
-		let defaultSpeechOutputAlways = defaults.SpeechOutputAlways;
-		let defaultSpeechRate = defaults.SpeechRate;
-		let defaultSpeechPitch = defaults.SpeechPitch;
-		let defaultTTSLanguage = defaults.TTSLanguage;
-		let defaultPrefLanguage = defaults.PrefLanguage;
-		let defaultCountryCode = defaults.CountryCode;
-		let defaultCountryDialCode =defaults.CountryDialCode;
-		let defaultPhoneNo = defaults.PhoneNo;
-		let TTSBrowserSupport;
-		if ('speechSynthesis' in window) {
-			TTSBrowserSupport = true;
-		} else {
-			TTSBrowserSupport = false;
-			console.warn('The current browser does not support the SpeechSynthesis API.')
-		}
-		let STTBrowserSupport;
-		const SpeechRecognition = window.SpeechRecognition
-			|| window.webkitSpeechRecognition
-			|| window.mozSpeechRecognition
-			|| window.msSpeechRecognition
-			|| window.oSpeechRecognition
+	let defaults = UserPreferencesStore.getPreferences();
+	let defaultServer = defaults.Server;
+	let defaultTheme = defaults.Theme;
+	let defaultEnterAsSend = defaults.EnterAsSend;
+	let defaultMicInput = defaults.MicInput;
+	let defaultSpeechOutput = defaults.SpeechOutput;
+	let defaultSpeechOutputAlways = defaults.SpeechOutputAlways;
+	let defaultSpeechRate = defaults.SpeechRate;
+	let defaultSpeechPitch = defaults.SpeechPitch;
+	let defaultTTSLanguage = defaults.TTSLanguage;
+	let defaultPrefLanguage = defaults.PrefLanguage;
+	let defaultChecked = defaults.checked;
+	let defaultServerUrl= defaults.serverUrl;
+	let defaultCountryCode = defaults.CountryCode;
+	let defaultCountryDialCode =defaults.CountryDialCode;
+	let defaultPhoneNo = defaults.phoneNo;
+	let TTSBrowserSupport;
+	if ('speechSynthesis' in window) {
+	  TTSBrowserSupport = true;
+	} else {
+	  TTSBrowserSupport = false;
+	  console.warn('The current browser does not support the SpeechSynthesis API.')
+	}
+	let STTBrowserSupport;
+	const SpeechRecognition = window.SpeechRecognition
+	  || window.webkitSpeechRecognition
+	  || window.mozSpeechRecognition
+	  || window.msSpeechRecognition
+	  || window.oSpeechRecognition
 
-		if (SpeechRecognition != null) {
-			STTBrowserSupport = true;
-		} else {
-			STTBrowserSupport = false;
-			console.warn('The current browser does not support the SpeechRecognition API.');
-		}
+	if (SpeechRecognition != null) {
+	  STTBrowserSupport = true;
+	} else {
+	  STTBrowserSupport = false;
+	  console.warn('The current browser does not support the SpeechRecognition API.');
+	}
 		this.setState({
 			theme: defaultTheme,
-			selectedSetting: 'ChatApp Settings',
 			enterAsSend: defaultEnterAsSend,
 			micInput: defaultMicInput,
 			speechOutput: defaultSpeechOutput,
 			speechOutputAlways: defaultSpeechOutputAlways,
 			server: defaultServer,
-			serverUrl: '',
+			serverUrl: defaultServerUrl,
 			serverFieldError: false,
-			checked: false,
+			checked: defaultChecked,
 			validForm: true,
 			showLanguageSettings: false,
 			speechRate: defaultSpeechRate,
@@ -151,6 +158,14 @@ class Settings extends Component {
 		this.customServerMessage = '';
 		this.TTSBrowserSupport = TTSBrowserSupport;
 		this.STTBrowserSupport = STTBrowserSupport;
+	}
+
+	/**
+	 * Event handler for 'change' events coming from the UserPreferencesStore
+	 */
+	_onChangeSettings() {
+	  this.setInitialSettings();
+	  this.setDefaultsSettings();
 	}
 
 	// Show change server dialog
@@ -200,13 +215,15 @@ class Settings extends Component {
 		let newSpeechPitch = this.state.speechPitch;
 		let newTTSLanguage = this.state.ttsLanguage;
 		let newPrefLanguage = this.state.PrefLanguage;
+		let checked = this.state.checked;
+		let serverUrl = this.state.serverUrl;
 		let newCountryCode = !this.state.countryCode?
 		this.intialSettings.countryCode:this.state.countryCode;
 		let newCountryDialCode = !this.state.countryDialCode?
 		this.intialSettings.countryDialCode:this.state.countryDialCode;
 		let newPhoneNo = this.state.phoneNo;
-		if (newDefaultServer.slice(-1) === '/') {
-			newDefaultServer = newDefaultServer.slice(0, -1);
+		if(newDefaultServer.slice(-1)==='/'){
+			newDefaultServer = newDefaultServer.slice(0,-1);
 		}
 		let vals = {
 			theme: newTheme,
@@ -221,7 +238,9 @@ class Settings extends Component {
 			prefLanguage: newPrefLanguage,
 			countryCode: newCountryCode,
 			countryDialCode: newCountryDialCode,
-			phoneNo: newPhoneNo
+			phoneNo: newPhoneNo,
+			checked,
+			serverUrl
 		}
 
 		let settings = Object.assign({}, vals);
@@ -236,21 +255,20 @@ class Settings extends Component {
 
 	// Store the settings in stores and server
 	implementSettings = (values) => {
-		let currSettings = UserPreferencesStore.getPreferences();
-		let resetVoice = false;
-		if (currSettings.SpeechOutput !== values.speechOutput) {
-			resetVoice = true;
-		}
-		if (currSettings.SpeechOutputAlways !== values.speechOutputAlways) {
-			resetVoice = true;
-		}
-		Actions.settingsChanged(values);
-		if (resetVoice) {
-			Actions.resetVoice();
-		}
-		this.props.history.push(`/settings?tab=${this.state.selectedSetting}`);
-		// window.location.reload();
+	let currSettings = UserPreferencesStore.getPreferences();
+	let resetVoice = false;
+	if(currSettings.SpeechOutput !== values.speechOutput){
+	  resetVoice = true;
 	}
+	if(currSettings.SpeechOutputAlways !== values.speechOutputAlways){
+	  resetVoice = true;
+	}
+	Actions.settingsChanged(values);
+	if(resetVoice){
+	  Actions.resetVoice();
+	}
+	this.props.history.push(`/settings?tab=${this.state.selectedSetting}`);
+  }
 
 	// Handle change to theme settings
 	handleSelectChange = (event, value) => {
@@ -418,6 +436,7 @@ class Settings extends Component {
 
 	componentWillUnmount() {
 		MessageStore.removeChangeListener(this._onChange.bind(this));
+		UserPreferencesStore.removeChangeListener(this._onChangeSettings.bind(this));
 	}
 
 	// Populate language list
@@ -434,10 +453,9 @@ class Settings extends Component {
 	}
 
 	componentDidMount() {
-		console.log('this.state',this.state.intialSettings);
 		document.title = 'Settings - SUSI.AI - Open Source Artificial Intelligence for Personal Assistants, Robots, Help Desks and Chatbots';
 		MessageStore.addChangeListener(this._onChange.bind(this));
-
+		UserPreferencesStore.addChangeListener(this._onChangeSettings.bind(this));
 		this.setState({
 			search: false,
 		});
@@ -450,6 +468,12 @@ class Settings extends Component {
 				selectedSetting: tab
 			})
 		}
+		else{
+			this.setState({
+			selectedSetting: cookies.get('loggedIn')? 'Account':'ChatApp Settings'
+		})
+		}
+		this.showWhenLoggedIn='none';
 	}
 
 	// Generate language list drop down menu items
@@ -486,15 +510,21 @@ class Settings extends Component {
 		this.setState({ settingNo: e.target.innerText });
 	}
 
-	displaySaveChangesButton = () => {
-		let selectedSetting = this.state.selectedSetting;
-		if (selectedSetting === 'Account Settings') {
+	displaySaveChangesButton = () =>{
+		let selectedSetting=this.state.selectedSetting;
+		if(selectedSetting==='Password')
+		{
 			return false;
 		}
 		if (selectedSetting === 'Connect to SUSI Hardware') {
 			return false;
 		}
-		if (selectedSetting === 'Server Settings' && cookies.get('loggedIn')) {
+		if(selectedSetting==='Account')
+		{
+			return false;
+		}
+		if(selectedSetting==='Server Settings' && cookies.get('loggedIn'))
+		{
 			return false;
 		}
 		return true;// display the button otherwise
@@ -537,8 +567,16 @@ class Settings extends Component {
 		else if (intialSettings.countryCode !== classState.countryCode) {
 			somethingToSave = true;
 		}
+		else if(intialSettings.serverUrl !== classState.serverUrl)
+		{
+			somethingToSave=true;
+		}
 		else if (intialSettings.phoneNo !== classState.phoneNo) {
 			somethingToSave = true;
+		}
+		else if(intialSettings.PrefLanguage!==classState.PrefLanguage)
+		{
+			somethingToSave=true;
 		}
 		return somethingToSave;
 	}
@@ -558,6 +596,17 @@ class Settings extends Component {
 			'padding': 0,
 			textAlign: 'center'
 		}
+		const themeBackgroundColor=this.state.intialSettings.theme==='dark'?'#19324c':'#fff';
+		const themeForegroundColor=this.state.intialSettings.theme==='dark'?'#fff':'#272727';
+
+		const floatingLabelStyle={
+			color:'#9e9e9e'
+		}
+		const underlineStyle ={
+			color:this.state.intialSettings.theme==='dark'?'#9E9E9E':null,
+			borderColor:this.state.intialSettings.theme==='dark'?'#9E9E9E':null
+		}
+		const menuIconColor=this.state.intialSettings.theme==='dark'?themeForegroundColor:null;
 		countryData.countries.all.sort(function (a, b) {
 			if (a.name < b.name) { return -1 };
 			if (a.name > b.name) { return 1 };
@@ -612,6 +661,10 @@ class Settings extends Component {
 			marginLeft: '10px',
 		}
 
+		const radioIconStyle = {
+			fill: '#4285f4'
+		}
+
 		let currentSetting;
 
 
@@ -627,12 +680,13 @@ class Settings extends Component {
 					}}>
 						<Translate text="Select Server" />
 					</div>
-					<div style={{ textAlign: 'left', marginLeft: '30px !important' }}>
-						<CustomServer
-							checked={this.state.checked}
-							serverUrl={this.state.serverUrl}
-							customServerMessage={this.customServerMessage}
-							onServerChange={this.handleServeChange} />
+					<div style={{textAlign : 'left', marginLeft: '30px !important'}}>
+					<CustomServer
+						checked={this.state.checked}
+						settings={this.state.intialSettings}
+						serverUrl={this.state.serverUrl}
+						customServerMessage={this.customServerMessage}
+						onServerChange={this.handleServeChange}/>
 					</div>
 				</div>
 			)
@@ -649,11 +703,12 @@ class Settings extends Component {
 							}}>
 								<Translate text="Select Server" />
 							</div>
-							<FlatButton
-								className='settingsBtns'
-								style={Buttonstyles}
-								label={<Translate text="Select backend server for the app" />}
-								onClick={this.handleServer} />
+								<FlatButton
+									className='settingsBtns'
+									labelStyle={{color:themeForegroundColor}}
+									style={Buttonstyles}
+									label={<Translate text="Select backend server for the app"/>}
+									onClick={this.handleServer} />
 						</div>
 					</div>
 				)
@@ -676,7 +731,8 @@ class Settings extends Component {
 							</div>
 							<Toggle
 								className='settings-toggle'
-								label={<Translate text="Enable mic to give voice input" />}
+								label={<Translate text="Enable mic to give voice input"/>}
+								labelStyle={{color:themeForegroundColor}}
 								disabled={!this.STTBrowserSupport}
 								onToggle={this.handleMicInput}
 								toggled={this.state.micInput} />
@@ -704,12 +760,16 @@ class Settings extends Component {
 						name="Theme"
 						valueSelected={this.state.theme}>
 						<RadioButton
-							style={{ width: '20%', display: 'block' }}
+							style={{width: '20%', display: 'block'}}
+							iconStyle={radioIconStyle}
+							labelStyle={{color:themeForegroundColor}}
 							value='light'
 							label={<Translate text="Light" />}
 						/>
 						<RadioButton
-							style={{ width: '20%', display: 'inline-block' }}
+							style={{width: '20%', display: 'inline-block'}}
+							iconStyle={radioIconStyle}
+							labelStyle={{color:themeForegroundColor}}
 							value='dark'
 							label={<Translate text="Dark" />}
 						/>
@@ -721,55 +781,54 @@ class Settings extends Component {
 		else if (this.state.selectedSetting === 'Speech Settings') {
 			currentSetting = (
 				<div style={divStyle}>
-					<div>
-						<div style={{
-							marginTop: '10px',
-							'marginBottom': '0px',
-							fontSize: '15px',
-							fontWeight: 'bold'
-						}}>
-							<Translate text="Speech Output" />
-						</div>
-						<Toggle
-							className='settings-toggle'
-							label={<Translate text="Enable speech output only for speech input" />}
-							disabled={!this.TTSBrowserSupport}
-							onToggle={this.handleSpeechOutput}
-							toggled={this.state.speechOutput} />
-					</div>
-					<div>
-						<div style={{
-							marginTop: '10px',
-							'marginBottom': '0px',
-							fontSize: '15px',
-							fontWeight: 'bold'
-						}}>
-							<Translate text="Speech Output Always ON" />
-						</div>
-						<Toggle
-							className='settings-toggle'
-							label={<Translate text="Enable speech output regardless of input type" />}
-							disabled={!this.TTSBrowserSupport}
-							onToggle={this.handleSpeechOutputAlways}
-							toggled={this.state.speechOutputAlways} />
-					</div>
-					<div>
-						<div style={{
-							marginTop: '10px',
-							'marginBottom': '0px',
-							fontSize: '15px',
-							fontWeight: 'bold'
-						}}>
-							<Translate text="Speech Output Language" />
-						</div>
-						<FlatButton
-							className='settingsBtns'
-							style={Buttonstyles}
-							label={<Translate text="Select Default Language" />}
-
-							disabled={!this.TTSBrowserSupport}
-							onClick={this.handleLanguage.bind(this, true)} />
-					</div>
+								<div>
+									<div style={{
+										marginTop: '10px',
+										'marginBottom':'0px',
+										fontSize: '15px',
+										fontWeight: 'bold'}}>
+										<Translate text="Speech Output"/>
+									</div>
+									<Toggle
+										className='settings-toggle'
+										label={<Translate text="Enable speech output only for speech input"/>}
+										disabled={!this.TTSBrowserSupport}
+										labelStyle={{color:themeForegroundColor}}
+										onToggle={this.handleSpeechOutput}
+										toggled={this.state.speechOutput}/>
+								</div>
+								<div>
+									<div style={{
+										marginTop: '10px',
+										'marginBottom':'0px',
+										fontSize: '15px',
+										fontWeight: 'bold'}}>
+										<Translate text="Speech Output Always ON"/>
+									</div>
+									<Toggle
+										className='settings-toggle'
+										label={<Translate text="Enable speech output regardless of input type"/>}
+										disabled={!this.TTSBrowserSupport}
+										labelStyle={{color:themeForegroundColor}}
+										onToggle={this.handleSpeechOutputAlways}
+										toggled={this.state.speechOutputAlways}/>
+								</div>
+								<div>
+									<div style={{
+										marginTop: '10px',
+										'marginBottom':'0px',
+										fontSize: '15px',
+										fontWeight: 'bold'}}>
+										<Translate text="Speech Output Language"/>
+									</div>
+									<FlatButton
+										className='settingsBtns'
+										style={Buttonstyles}
+										label={<Translate text="Select Default Language"/>}
+										labelStyle={{color:themeForegroundColor}}
+										disabled={!this.TTSBrowserSupport}
+										onClick={this.handleLanguage.bind(this,true)} />
+								</div>
 				</div>
 			)
 		}
@@ -787,35 +846,57 @@ class Settings extends Component {
 							<Translate text="Select Default Language" />
 						</div>
 					</span>
-					<DropDownMenu
-						value={voiceOutput.voiceLang}
-						disabled={!this.TTSBrowserSupport}
-						onChange={this.handlePrefLang}>
-						{voiceOutput.voiceMenu}
-					</DropDownMenu>
+						<DropDownMenu
+							value={voiceOutput.voiceLang}
+							disabled={!this.TTSBrowserSupport}
+							labelStyle={{color:themeForegroundColor}}
+							menuStyle={{backgroundColor:themeBackgroundColor}}
+							menuItemStyle={{color:themeForegroundColor}}
+							onChange={this.handlePrefLang}>
+							{voiceOutput.voiceMenu}
+					 </DropDownMenu>
 				</div>
 			)
 		}
 
-		else if (this.state.selectedSetting === 'Account Settings' && cookies.get('loggedIn')) {
+		else if(this.state.selectedSetting === 'Password' && cookies.get('loggedIn')) {
 			currentSetting =
-				<div style={divStyle}>
-					<span>
-						<div style={{
-							marginTop: '10px',
-							'marginBottom': '0px',
-							fontSize: '15px',
-							fontWeight: 'bold'
-						}}>
-							<Translate text="Change your Account Password" />
-						</div>
-						<FlatButton
-							className='settingsBtns'
-							style={Buttonstyles}
-							label={<Translate text="Change Password" />}
-							onClick={this.handleChangePassword} />
-					</span>
-				</div>
+			<div style={divStyle}>
+				<span>
+					<div style={{
+						marginTop: '10px',
+						'marginBottom':'0px',
+						fontSize: '15px',
+						fontWeight: 'bold'}}>
+						<Translate text="Change your Account Password"/>
+					</div>
+					<ChangePassword settings={this.state.intialSettings} {...this.props} />
+				</span>
+			</div>
+		}
+
+		else if(this.state.selectedSetting === 'Account' && cookies.get('loggedIn')) {
+			currentSetting =
+			<div style={divStyle}>
+				<span>
+					<div style={{
+						marginTop: '10px',
+						'marginBottom':'0px',
+						fontSize: '15px',
+						fontWeight: 'bold'}}>
+						<Translate text="Your Account"/>
+					</div>
+					<TextField
+						name="email"
+						disabled={true}
+						underlineDisabledStyle={UserPreferencesStore.getTheme()==='dark'?underlineStyle:null}
+						underlineStyle={underlineStyle}
+						inputStyle={{color:UserPreferencesStore.getTheme()==='dark'?'#fff':'#333'}}
+                  		value={this.state.identity.name}
+						floatingLabelStyle={floatingLabelStyle}
+                  		floatingLabelText={<Translate text="Your Email"/>} />
+				</span>
+			</div>
 		}
 
 		else if (this.state.selectedSetting === 'Connect to SUSI Hardware') {
@@ -831,12 +912,7 @@ class Settings extends Component {
 						}}>
 							<Translate text="Connect to SUSI Hardware" />
 						</div>
-						<FlatButton
-							className='settingsBtns'
-							style={Buttonstyles}
-							id="hardwareBtn"
-							label={<Translate text="Add address to connect to Hardware" />}
-							onClick={this.handleHardware} />
+						<HardwareComponent settings={this.state.intialSettings} {...this.props} />
 					</div>
 				</span>
 			)
@@ -868,7 +944,6 @@ class Settings extends Component {
 							'marginBottom': '0px',
 							marginLeft: '30px',
 							fontSize: '15px',
-							color: '#0f0f0f',
 							fontWeight: 'bold'
 						}}>
 							<Translate text="Add your phone number" />
@@ -890,6 +965,9 @@ class Settings extends Component {
 							<Translate text="Country/region : " />
 							<DropDownMenu maxHeight={300}
 								style={{ width: '250px', position: 'relative', top: '15px' }}
+								labelStyle={{color:themeForegroundColor}}
+								menuStyle={{backgroundColor:themeBackgroundColor}}
+								menuItemStyle={{color:themeForegroundColor}}
 								value={this.state.countryCode ? this.state.countryCode : 'US'}
 								onChange={this.handleCountryChange}>
 								{countries}
@@ -905,12 +983,17 @@ class Settings extends Component {
 							<Translate text="Phone number : " />
 							<TextField name="selectedCountry"
 								disabled={true}
+								underlineDisabledStyle={UserPreferencesStore.getTheme()==='dark'?underlineStyle:null}
+								inputStyle={{color:UserPreferencesStore.getTheme()==='dark'?'#fff':'#333'}}
+		                  		floatingLabelStyle={floatingLabelStyle}
 								value={countryData.countries[this.state.countryCode ? this.state.countryCode : 'US'].countryCallingCodes[0]}
 								style={{ width: '45px', marginLeft: '30px' }}
 							/>
 							<TextField name="phonenumber"
 								style={{ width: '150px', marginLeft: '5px' }}
 								onChange={this.handleTelephoneNoChange}
+								inputStyle={{color:UserPreferencesStore.getTheme()==='dark'?'#fff':'#333'}}
+		                  		floatingLabelStyle={floatingLabelStyle}
 								value={this.state.phoneNo}
 								floatingLabelText={<Translate text="Phone number" />} />
 						</div>
@@ -933,118 +1016,128 @@ class Settings extends Component {
 						className='settings-toggle'
 						label={<Translate text="Send message by pressing ENTER" />}
 						onToggle={this.handleEnterAsSend}
-						toggled={this.state.enterAsSend} />
+						labelStyle={{color:themeForegroundColor}}
+						toggled={this.state.enterAsSend}/>
 				</div>);
 		}
-		let blueThemeColor = { color: 'rgb(66, 133, 244)' };
-		let menuItems = cookies.get('loggedIn') ?
-			<div>
-				<div className="settings-list">
-					<Menu
-						onItemTouchTap={this.loadSettings}
-						selectedMenuItemStyle={blueThemeColor}
-						style={{ width: '100%' }}
-						value={this.state.selectedSetting}
-					>
-						<MenuItem value='ChatApp Settings' className="setting-item" leftIcon={<ChatIcon />}>ChatApp Settings<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Theme' className="setting-item" leftIcon={<ThemeIcon />}>Theme<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Mic Settings' className="setting-item" leftIcon={<VoiceIcon />}>Mic Settings<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Speech Settings' className="setting-item" leftIcon={<SpeechIcon />}>Speech Settings<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Text Language Settings' className="setting-item" leftIcon={<LanguageIcon />}>Text Language Settings<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Server Settings' className="setting-item" leftIcon={<ServerIcon />}>Server Settings<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Connect to SUSI Hardware' className="setting-item" leftIcon={<HardwareIcon />}>Connect to SUSI Hardware<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Account Settings' className="setting-item" leftIcon={<AccountIcon />}>Account Settings<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Mobile' className="setting-item" leftIcon={<MobileIcon />}>Mobile<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-					</Menu>
-				</div>
-				<div className="settings-list-dropdown">
-					<DropDownMenu
-						selectedMenuItemStyle={blueThemeColor}
-						onChange={this.loadSettings}
-						value={this.state.selectedSetting}
-						style={{ width: '100%' }}
-						autoWidth={false}
-					>
-						<MenuItem primaryText='ChatApp Settings' value='ChatApp Settings' className="setting-item" />
-						<MenuItem primaryText='Theme' value='Theme' className="setting-item" />
-						<MenuItem primaryText='Mic Settings' value='Mic Settings' className="setting-item" />
-						<MenuItem primaryText='Speech Settings' value='Speech Settings' className="setting-item" />
-						<MenuItem primaryText='Text Language Settings' value='Text Language Settings' className="setting-item" />
-						<MenuItem primaryText='Server Settings' value='Server Settings' className="setting-item" />
-						<MenuItem primaryText='Connect to SUSI Hardware' value='Connect to SUSI Hardware' className="setting-item" />
-						<MenuItem primaryText='Account Settings' value='Account Settings' className="setting-item" />
-						<MenuItem primaryText='Mobile' value='Mobile' className="setting-item" />
-					</DropDownMenu>
-				</div>
-			</div>
+		let blueThemeColor={color: 'rgb(66, 133, 244)'};
+		let menuItems = cookies.get('loggedIn')?
+		<div>
+		<div className="settings-list">
+		<Menu
+			onItemTouchTap={this.loadSettings}
+			selectedMenuItemStyle={blueThemeColor}
+			style={{width:'100%'}}
+			value={this.state.selectedSetting}
+			>
+			<MenuItem style={{color:themeForegroundColor}} value='Account' className="setting-item" leftIcon={<AccountIcon color={menuIconColor}/>}>Account<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+			<hr className="break-line"/>
+			<MenuItem style={{color:themeForegroundColor}} value='Password' className="setting-item" leftIcon={<LockIcon color={menuIconColor}/>}>Password<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+			<hr className="break-line"/>
+			<MenuItem style={{color:themeForegroundColor}} value='ChatApp Settings' className="setting-item" leftIcon={<ChatIcon color={menuIconColor}/>}>ChatApp Settings<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+			<hr className="break-line"/>
+			<MenuItem style={{color:themeForegroundColor}} value='Theme' className="setting-item" leftIcon={<ThemeIcon color={menuIconColor}/>}>Theme<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+			<hr className="break-line"/>
+			<MenuItem style={{color:themeForegroundColor}} value='Mic Settings' className="setting-item" leftIcon={<VoiceIcon color={menuIconColor}/>}>Mic Settings<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+			<hr className="break-line"/>
+			<MenuItem style={{color:themeForegroundColor}} value='Speech Settings' className="setting-item" leftIcon={<SpeechIcon color={menuIconColor}/>}>Speech Settings<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+			<hr className="break-line"/>
+			<MenuItem style={{color:themeForegroundColor}} value='Text Language Settings' className="setting-item" leftIcon={<LanguageIcon color={menuIconColor}/>}>Text Language Settings<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+			<hr className="break-line"/>
+			<MenuItem style={{color:themeForegroundColor}} value='Server Settings' className="setting-item" leftIcon={<ServerIcon color={menuIconColor}/>}>Server Settings<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+			<hr className="break-line"/>
+			<MenuItem style={{color:themeForegroundColor}} value='Connect to SUSI Hardware' className="setting-item"  leftIcon={<HardwareIcon color={menuIconColor}/>}>Connect to SUSI Hardware<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+			<hr className="break-line"/>
+			<MenuItem style={{color:themeForegroundColor}} value='Mobile' className="setting-item" leftIcon={<MobileIcon color={menuIconColor} />}>Mobile<ChevronRight style={{color:themeForegroundColor}} className="right-chevron" /></MenuItem>
+		</Menu>
+		</div>
+		<div className="settings-list-dropdown">
+		<DropDownMenu
+			selectedMenuItemStyle={blueThemeColor}
+			onChange={this.loadSettings}
+			value={this.state.selectedSetting}
+			labelStyle={{color:themeForegroundColor}}
+			menuStyle={{backgroundColor:themeBackgroundColor}}
+			menuItemStyle={{color:themeForegroundColor}}
+			style={{width:'100%'}}
+			autoWidth={false}
+        >
+				<MenuItem primaryText='Account' value='Account' className="setting-item"/>
+				<MenuItem primaryText='Password' value='Password' className="setting-item"/>
+				<MenuItem primaryText='ChatApp Settings' value='ChatApp Settings' className="setting-item"/>
+				<MenuItem primaryText='Theme' value='Theme' className="setting-item"/>
+				<MenuItem primaryText='Mic Settings' value='Mic Settings' className="setting-item"/>
+				<MenuItem primaryText='Speech Settings'value='Speech Settings' className="setting-item"/>
+				<MenuItem primaryText='Text Language Settings'value='Text Language Settings' className="setting-item"/>
+				<MenuItem primaryText='Server Settings'value='Server Settings' className="setting-item"/>
+				<MenuItem primaryText='Connect to SUSI Hardware' value='Connect to SUSI Hardware' className="setting-item"/>
+				<MenuItem primaryText='Mobile' value='Mobile' className="setting-item" />
+		</DropDownMenu>
+		</div>
+		</div>
 
-			:
-			<div>
-				<div className="settings-list">
-					<Menu
-						onItemTouchTap={this.loadSettings}
-						selectedMenuItemStyle={blueThemeColor}
-						style={{ width: '100%' }}
-						value={this.state.selectedSetting}
-					>
-						<MenuItem value='ChatApp Settings' className="setting-item" leftIcon={<ChatIcon />}>ChatApp Settings<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Theme' className="setting-item" leftIcon={<ThemeIcon />}>Theme<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Mic Settings' className="setting-item" leftIcon={<VoiceIcon />}>Mic Settings<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Speech Settings' className="setting-item" leftIcon={<SpeechIcon />}>Speech Settings<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Text Language Settings' className="setting-item" leftIcon={<LanguageIcon />}>Text Language Settings<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Server Settings' className="setting-item" leftIcon={<ServerIcon />}>Server Settings<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-						<MenuItem value='Connect to SUSI Hardware' className="setting-item" leftIcon={<HardwareIcon />}>Connect to SUSI Hardware<ChevronRight className="right-chevron" /></MenuItem>
-						<hr className="break-line" />
-					</Menu>
-				</div>
-				<div className="settings-list-dropdown">
-					<DropDownMenu
-						selectedMenuItemStyle={blueThemeColor}
-						onChange={this.loadSettings}
-						value={this.state.selectedSetting}
-						style={{ width: '100%' }}
-						autoWidth={false}
-					>
-						<MenuItem primaryText='ChatApp Settings' value='ChatApp Settings' className="setting-item" />
-						<MenuItem primaryText='Theme' value='Theme' className="setting-item" />
-						<MenuItem primaryText='Mic Settings' value='Mic Settings' className="setting-item" />
-						<MenuItem primaryText='Speech Settings' value='Speech Settings' className="setting-item" />
-						<MenuItem primaryText='Text Language Settings' value='Text Language Settings' className="setting-item" />
-						<MenuItem primaryText='Server Settings' value='Server Settings' className="setting-item" />
-						<MenuItem primaryText='Connect to SUSI Hardware' value='Connect to SUSI Hardware' className="setting-item" />
-					</DropDownMenu>
-				</div>
-			</div>
+		:
+		<div>
+		<div className="settings-list">
+		<Menu
+			onItemTouchTap={this.loadSettings}
+			selectedMenuItemStyle={blueThemeColor}
+			style={{width:'100%'}}
+			value={this.state.selectedSetting}
+			>
+				<MenuItem style={{color:themeForegroundColor}} value='ChatApp Settings' className="setting-item" leftIcon={<ChatIcon color={menuIconColor}/>}>ChatApp Settings<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+				<hr className="break-line"/>
+				<MenuItem style={{color:themeForegroundColor}} value='Theme' className="setting-item" leftIcon={<ThemeIcon color={menuIconColor}/>}>Theme<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+				<hr className="break-line"/>
+				<MenuItem style={{color:themeForegroundColor}} value='Mic Settings' className="setting-item" leftIcon={<VoiceIcon color={menuIconColor}/>}>Mic Settings<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+				<hr className="break-line"/>
+				<MenuItem style={{color:themeForegroundColor}} value='Speech Settings' className="setting-item" leftIcon={<SpeechIcon color={menuIconColor}/>}>Speech Settings<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+				<hr className="break-line"/>
+				<MenuItem style={{color:themeForegroundColor}} value='Text Language Settings' className="setting-item" leftIcon={<LanguageIcon color={menuIconColor}/>}>Text Language Settings<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+				<hr className="break-line"/>
+				<MenuItem style={{color:themeForegroundColor}} value='Server Settings' className="setting-item" leftIcon={<ServerIcon color={menuIconColor}/>}>Server Settings<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+				<hr className="break-line"/>
+				<MenuItem style={{color:themeForegroundColor}} value='Connect to SUSI Hardware' className="setting-item"  leftIcon={<HardwareIcon color={menuIconColor}/>}>Connect to SUSI Hardware<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+		</Menu>
+		</div>
+		<div className="settings-list-dropdown">
+		<DropDownMenu
+			selectedMenuItemStyle={blueThemeColor}
+			onChange={this.loadSettings}
+			value={this.state.selectedSetting}
+			style={{width:'100%'}}
+			labelStyle={{color:themeForegroundColor}}
+			menuStyle={{backgroundColor:themeBackgroundColor}}
+			menuItemStyle={{color:themeForegroundColor}}
+			autoWidth={false}
+        >
+				<MenuItem primaryText='ChatApp Settings' value='ChatApp Settings' className="setting-item"/>
+				<MenuItem primaryText='Theme' value='Theme' className="setting-item"/>
+				<MenuItem primaryText='Mic Settings' value='Mic Settings' className="setting-item"/>
+				<MenuItem primaryText='Speech Settings'value='Speech Settings' className="setting-item"/>
+				<MenuItem primaryText='Text Language Settings'value='Text Language Settings' className="setting-item"/>
+				<MenuItem primaryText='Server Settings'value='Server Settings' className="setting-item"/>
+				<MenuItem primaryText='Connect to SUSI Hardware' value='Connect to SUSI Hardware' className="setting-item"/>
+		</DropDownMenu>
+		</div>
+		</div>
 
-		const menuStyle = {
-			height: 500,
-			marginTop: 20,
-			textAlign: 'center',
-			display: 'inline-block',
-		};
-		// to check if something has been modified or not
-		let somethingToSave = this.getSomethingToSave();
+	 const menuStyle = {
+					 height: 500,
+					 marginTop: 20,
+					 textAlign: 'center',
+					 display: 'inline-block',
+					 backgroundColor:themeBackgroundColor,
+					 color:themeForegroundColor
+	};
+	// to check if something has been modified or not
+	let somethingToSave=this.getSomethingToSave();
 		return (
 			<div className="settings-container">
-				<StaticAppBar {...this.props}
-					location={this.props.location} />
+		<StaticAppBar settings={this.state.intialSettings} {...this.props}
+			location={this.props.location} />
 				<div className='settingMenu'>
-					<Paper className='leftMenu tabStyle' zDepth={1}>
+					<Paper className='leftMenu tabStyle' zDepth={1} style={{backgroundColor:themeBackgroundColor, color:themeForegroundColor}}>
 						{menuItems}
 					</Paper>
 					<Paper className='rightMenu' style={menuStyle} zDepth={1}>
@@ -1088,46 +1181,34 @@ class Settings extends Component {
 					</div>
 				</Dialog>
 				{/* Change Server */}
-				<Dialog
-					actions={serverDialogActions}
-					modal={false}
-					open={this.state.showServerChangeDialog}
-					autoScrollBodyContent={true}
-					bodyStyle={bodyStyle}
-					onRequestClose={this.handleServerToggle.bind(this, false)}>
-					<div>
-						<h3><Translate text="Change Server" /></h3>
-						<Translate text="Please login again to change SUSI server" />
-						<Close style={closingStyle}
-							onTouchTap={this.handleServerToggle.bind(this, false)} />
-					</div>
-				</Dialog>
-				{/* Change Password */}
-				<Dialog
-					className='dialogStyle'
-					modal={false}
-					open={this.state.showChangePasswordDialog}
-					autoScrollBodyContent={true}
-					bodyStyle={bodyStyle}
-					contentStyle={{ width: '35%', minWidth: '300px' }}
-					onRequestClose={this.handleClose}>
-					<ChangePassword {...this.props} />
-					<Close style={closingStyle} onTouchTap={this.handleClose} />
-				</Dialog>
-				{/* ForgotPassword */}
-				<Dialog
+			<Dialog
+			  actions={serverDialogActions}
+			  modal={false}
+			  open={this.state.showServerChangeDialog}
+			  autoScrollBodyContent={true}
+			  bodyStyle={bodyStyle}
+			  onRequestClose={this.handleServerToggle.bind(this,false)}>
+			  <div>
+				<h3><Translate text="Change Server"/></h3>
+				<Translate text="Please login again to change SUSI server"/>
+				<Close style={closingStyle}
+				onTouchTap={this.handleServerToggle.bind(this,false)} />
+			  </div>
+			</Dialog>
+			{/* ForgotPassword */}
+			<Dialog
 					className='dialogStyle'
 					modal={false}
 					open={this.state.showForgotPassword}
 					autoScrollBodyContent={true}
-					contentStyle={{ width: '35%', minWidth: '300px' }}
+					contentStyle={{width: '35%',minWidth: '300px'}}
 					onRequestClose={this.handleClose}>
 					<ForgotPassword {...this.props}
-						showForgotPassword={this.handleForgotPassword} />
+					showForgotPassword={this.handleForgotPassword}/>
 					<Close style={closingStyle}
-						onTouchTap={this.handleClose} />
+					onTouchTap={this.handleClose}/>
 				</Dialog>
-			</div>);
+		</div>);
 	}
 }
 

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -391,9 +391,8 @@ class StaticAppBar extends Component {
                 </div>
             </div>
         );
-
+        const themeBackgroundColor = this.props.settings && this.props.settings.theme==='dark'?'rgb(25, 50, 76)':'#4285f4';
         return (
-
             <div>
                 <header className="nav-down" >
                     <AppBar
@@ -403,7 +402,7 @@ class StaticAppBar extends Component {
                         title={<div id="rightIconButton"><Link to='/' style={{ float: 'left', marginTop: '-10px',height:'25px',width:'122px' }}>
                             <img src={susiWhite} alt="susi-logo" className="siteTitle" /></Link><TopMenu /></div>}
                         style={{
-                            backgroundColor: '#4285f4', height: '46px',
+                            backgroundColor: themeBackgroundColor, height: '46px',
                             boxShadow: 'none'
                         }}
 						showMenuIconButton={showLeftMenu!=='none'}
@@ -477,6 +476,7 @@ class StaticAppBar extends Component {
 }
 StaticAppBar.propTypes = {
     history: PropTypes.object,
+    settings: PropTypes.object,
     location: PropTypes.object,
     closeVideo: PropTypes.func
 }

--- a/src/components/Translate/de.json
+++ b/src/components/Translate/de.json
@@ -80,6 +80,7 @@
    "Confirm New Password":"Bestätige neues Passwort",
    "Change":"Veränderung",
    "Worst":"Am schlimmsten",
+   "Too Insecure":"Zu unsicher",
    "Bad":"Schlecht",
    "Weak":"Schwach",
    "Good":"Gut",

--- a/src/components/Translate/en.json
+++ b/src/components/Translate/en.json
@@ -80,6 +80,7 @@
    "Confirm New Password":"Confirm New Password",
    "Change":"Change",
    "Worst":"Worst",
+   "Too Insecure":"Too Insecure",
    "Bad":"Bad",
    "Weak":"Weak",
    "Good":"Good",

--- a/src/constants/ChatConstants.js
+++ b/src/constants/ChatConstants.js
@@ -12,6 +12,7 @@ export default {
     STORE_HISTORY_MESSAGE: null,
     SERVER_CHANGED: null,
     INIT_SETTINGS: null,
+    INIT_IDENTITY: null,
     INIT_TTS_VOICES: null,
     SETTINGS_CHANGED: null,
     RESET_MESSAGE_VOICE: null,

--- a/src/stores/UserIdentityStore.js
+++ b/src/stores/UserIdentityStore.js
@@ -1,0 +1,74 @@
+import ChatAppDispatcher from '../dispatcher/ChatAppDispatcher';
+import ChatConstants from '../constants/ChatConstants';
+import { EventEmitter } from 'events';
+
+let ActionTypes = ChatConstants.ActionTypes;
+let CHANGE_EVENT = 'change';
+
+let _defaults = {
+    type:'email',
+    name:'',
+    anonymous:false
+};
+// Store handling all User Preferences
+let UserIdentityStore = {
+    ...EventEmitter.prototype,
+
+    emitChange() {
+        this.emit(CHANGE_EVENT);
+    },
+
+    getIdentity() {
+        return _defaults;
+    },
+
+    getType(){
+        return _defaults.type;
+    },
+
+    getName(){
+        return _defaults.name;// return email
+    },
+
+    getAnonymous(){
+        return _defaults.anonymous;
+    },
+
+    addChangeListener(callback) {
+        this.on(CHANGE_EVENT, callback);
+    },
+
+    removeChangeListener(callback) {
+        this.removeListener(CHANGE_EVENT, callback);
+    },
+
+};
+
+UserIdentityStore.dispatchToken = ChatAppDispatcher.register(action => {
+
+    switch (action.type) {
+
+        case ActionTypes.INIT_IDENTITY: {
+            let identity = action.identity;
+            if(identity.hasOwnProperty('type'))
+            {
+                _defaults.type=identity.type;
+            }
+            if(identity.hasOwnProperty('name'))
+            {
+                _defaults.name=identity.name;
+            }
+            if(identity.hasOwnProperty('anonymous'))
+            {
+                _defaults.anonymous=identity.anonymous;
+            }
+            UserIdentityStore.emitChange();
+            break;
+        }
+        default: {
+            // do nothing
+        }
+    }
+});
+
+export default UserIdentityStore;

--- a/src/stores/UserPreferencesStore.js
+++ b/src/stores/UserPreferencesStore.js
@@ -20,7 +20,9 @@ let _defaults = {
     ThemeValues: '',
     CountryCode: 'US',
     CountryDialCode: '+1',
-    PhoneNo: '',
+    phoneNo: '',
+    checked: false,
+    serverUrl:'https://api.susi.ai',
     BackgroundImage : ''
 
 };
@@ -91,14 +93,14 @@ let UserPreferencesStore = {
 };
 
 function checkForFalse ( valueToCheck ){
-    if(valueToCheck==='false'){
+    if(valueToCheck==='false' || !valueToCheck){
         return false;
     }
     return true;
 }
 
 function checkForTrue ( valueToCheck ){
-    if(valueToCheck==='true'){
+    if(valueToCheck==='true' || valueToCheck){
         return true;
     }
     return false;
@@ -153,6 +155,12 @@ UserPreferencesStore.dispatchToken = ChatAppDispatcher.register(action => {
             if(settings.hasOwnProperty('customThemeValue')){
                 _defaults.ThemeValues = settings.customThemeValue;
             }
+            if(settings.hasOwnProperty('checked')){
+                _defaults.checked = settings.checked;
+            }
+            if(settings.hasOwnProperty('serverUrl')){
+                _defaults.serverUrl = settings.serverUrl;
+            }
             if(settings.hasOwnProperty('countryDialCode')){
                 _defaults.CountryDialCode = settings.countryDialCode;
             }
@@ -166,7 +174,6 @@ UserPreferencesStore.dispatchToken = ChatAppDispatcher.register(action => {
             if(settings.hasOwnProperty('backgroundImage')){
                 _defaults.BackgroundImage = settings.backgroundImage;
             }
-
             UserPreferencesStore.emitChange();
             break;
         }
@@ -184,8 +191,11 @@ UserPreferencesStore.dispatchToken = ChatAppDispatcher.register(action => {
                 _defaults.TTSLanguage = settings.ttsLanguage;
                 _defaults.PrefLanguage = settings.prefLanguage;
                 _defaults.ThemeValues = settings.customThemeValue;
+                _defaults.checked = settings.checked;
+                _defaults.serverUrl = settings.serverUrl;
+                _defaults.phoneNo= settings.phoneNo;
+                _defaults.countryCode = settings.countryCode;
                 _defaults.BackgroundImage = settings.backgroundImage;
-
             }
             else{
                 if(settings.hasOwnProperty('theme')){
@@ -234,11 +244,21 @@ UserPreferencesStore.dispatchToken = ChatAppDispatcher.register(action => {
                 if(settings.hasOwnProperty('countryCode')){
                     _defaults.CountryCode = settings.countryCode;
                 }
-
                 if(settings.hasOwnProperty('backgroundImage')){
                     _defaults.BackgroundImage = settings.backgroundImage;
                 }
-
+                if(settings.hasOwnProperty('checked')){
+                    _defaults.checked = settings.checked;
+                }
+                else{
+                    _defaults.checked = false;
+                }
+                if(settings.hasOwnProperty('serverUrl')){
+                    _defaults.serverUrl = settings.serverUrl;
+                }
+                else{
+                    _defaults.serverUrl = '';
+                }
             }
             UserPreferencesStore.emitChange();
             break;


### PR DESCRIPTION
Fixes issue #840 

Changes:
- Fix bug in saving dark theme while signed in - fixes #841 
- Show User's email address
- Remove unnecessary popups in Settings page
- Disable refreshing after changing settings
- Save changes only for the changed settings of the current tab
- Enable dark theme in Settings page
- Integrate Mobile page

Demo Link: [clammy-park.surge.sh](http://clammy-park.surge.sh)

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/17807257/31841739-7d687700-b608-11e7-9f92-793b2324c67b.png)
![image](https://user-images.githubusercontent.com/17807257/31841777-a0c8862c-b608-11e7-83d6-26893e3d6a48.png)

