### PR TITLE
Remove listener for onspeechend

### DIFF
--- a/src/components/ChatApp/MessageComposer.react.js
+++ b/src/components/ChatApp/MessageComposer.react.js
@@ -74,11 +74,8 @@ class MessageComposer extends Component {
     })
   }
 
-  onspeechend = () => {
-    this.onEnd();
-  }
-
   onEnd = () => {
+    console.log('onend');
     this.setState({
       start: false,
       stop: false,

--- a/src/components/ChatApp/VoiceRecognition.js
+++ b/src/components/ChatApp/VoiceRecognition.js
@@ -79,8 +79,7 @@ class VoiceRecognition extends Component {
   componentDidMount () {
     const events = [
       { name: 'start', action: this.props.onStart },
-      { name: 'end', action: this.props.onEnd },
-      { name: 'onspeechend', action: this.props.onspeechend }
+      { name: 'end', action: this.props.onEnd }
     ]
 
     events.forEach(event => {
@@ -105,7 +104,6 @@ VoiceRecognition.propTypes = {
   onStart: PropTypes.func,
   onEnd : PropTypes.func,
   onResult: PropTypes.func,
-  onspeechend: PropTypes.func,
   continuous: PropTypes.bool,
   lang: PropTypes.string,
   stop: PropTypes.bool


### PR DESCRIPTION
Fixes issue #863 (onspeechend is never called)

Changes: Remove event listener `onspeechend` function which was listening to the wrong event `onspeechend` instead of `speechend`. Listening to the correct event `speechend` would result in two `speech to text` results generated since `onspeechend` was calling `onEnd`, but that is not required in this case since `onEnd` is automatically invoked when `speech recognition ends`.

Demo Link: https://silent-language.surge.sh/