### PR TITLE
Reduce wait time for Speech and remove onspeechend listener

### DIFF
--- a/src/components/ChatApp/MessageComposer.react.js
+++ b/src/components/ChatApp/MessageComposer.react.js
@@ -55,6 +55,7 @@ class MessageComposer extends Component {
       result: '',
       animate: false,
       rows: 1,
+      recognizing: false,
       currentArrowIndex:0// store the index for moving through messages using key
     };
     this.rowComplete = 0;
@@ -74,14 +75,20 @@ class MessageComposer extends Component {
     })
   }
 
+  onSpeechStart = () => {
+    this.setState({
+      recognizing: true
+    });
+  }
+
   onEnd = () => {
-    console.log('onend');
     this.setState({
       start: false,
       stop: false,
       open: false,
       animate: false,
-      color: '#000'
+      color: '#000',
+      recognizing: false
     });
 
     let voiceResponse = false;
@@ -192,6 +199,7 @@ class MessageComposer extends Component {
             onspeechend={this.onspeechend}
             onResult={this.onResult}
             onEnd={this.onEnd}
+            onSpeechStart={this.onSpeechStart}
             continuous={true}
             lang="en-US"
             stop={this.state.stop}
@@ -272,6 +280,11 @@ class MessageComposer extends Component {
       }
       this.setState({ text: '',currentArrowIndex:0 });
     }
+    setTimeout(function(){
+      if(this.state.recognizing === false) {
+        this.speakDialogClose();
+      }
+    }.bind(this),5000);
   }
 
   _onChange(event, value) {

--- a/src/components/ChatApp/MessageComposer.react.js
+++ b/src/components/ChatApp/MessageComposer.react.js
@@ -74,11 +74,8 @@ class MessageComposer extends Component {
     })
   }
 
-  onspeechend = () => {
-    this.onEnd();
-  }
-
   onEnd = () => {
+    console.log('onend');
     this.setState({
       start: false,
       stop: false,

--- a/src/components/ChatApp/VoiceRecognition.js
+++ b/src/components/ChatApp/VoiceRecognition.js
@@ -59,9 +59,9 @@ class VoiceRecognition extends Component {
   }
 
   onspeechend = () => {
-    console.log('no sound detected');
     this.recognition.stop()
   }
+
   stop = () => {
     this.recognition.stop()
   }
@@ -79,7 +79,8 @@ class VoiceRecognition extends Component {
   componentDidMount () {
     const events = [
       { name: 'start', action: this.props.onStart },
-      { name: 'end', action: this.props.onEnd }
+      { name: 'end', action: this.props.onEnd },
+      { name: 'speechstart', action: this.props.onSpeechStart}
     ]
 
     events.forEach(event => {
@@ -102,6 +103,7 @@ class VoiceRecognition extends Component {
 
 VoiceRecognition.propTypes = {
   onStart: PropTypes.func,
+  onSpeechStart: PropTypes.func,
   onEnd : PropTypes.func,
   onResult: PropTypes.func,
   continuous: PropTypes.bool,

--- a/src/components/ChatApp/VoiceRecognition.js
+++ b/src/components/ChatApp/VoiceRecognition.js
@@ -79,8 +79,7 @@ class VoiceRecognition extends Component {
   componentDidMount () {
     const events = [
       { name: 'start', action: this.props.onStart },
-      { name: 'end', action: this.props.onEnd },
-      { name: 'onspeechend', action: this.props.onspeechend }
+      { name: 'end', action: this.props.onEnd }
     ]
 
     events.forEach(event => {
@@ -105,7 +104,6 @@ VoiceRecognition.propTypes = {
   onStart: PropTypes.func,
   onEnd : PropTypes.func,
   onResult: PropTypes.func,
-  onspeechend: PropTypes.func,
   continuous: PropTypes.bool,
   lang: PropTypes.string,
   stop: PropTypes.bool


### PR DESCRIPTION
Fixes issue #863 #808 

Changes: 
**#863** : Remove event listener onspeechend function which was listening to the wrong event onspeechend instead of speechend. Listening to the correct event speechend would result in two speech to text results generated since onspeechend was calling onEnd, but that is not required in this case since onEnd is automatically invoked when speech recognition ends.

**#808** : Close the speak dialog after 5 seconds of inactivity in speech,(close speak dialog after 5 seconds of a user clicking the mic button if the user does not speak anything till that time.)

Demo Link: https://wiggly-range.surge.sh/