### PR TITLE
Retain bottom text field when search is activated - fixes #823

### DIFF
--- a/src/components/ChatApp/MessageComposer.react.js
+++ b/src/components/ChatApp/MessageComposer.react.js
@@ -183,7 +183,7 @@ class MessageComposer extends Component {
   }
 
   componentDidMount() {
-    document.getElementById('scroll').focus();
+
   }
 
   render() {
@@ -214,6 +214,7 @@ class MessageComposer extends Component {
             onKeyDown={this._onKeyDown.bind(this)}
             ref={(textarea) => { this.nameInput = textarea; }}
             style={{ background: this.props.textarea, color: this.props.textcolor, lineHeight: '15px' }}
+            autoFocus={this.props.focus}
           />
         </div>
         <IconButton
@@ -363,6 +364,7 @@ MessageComposer.propTypes = {
   speechOutput: PropTypes.bool,
   speechOutputAlways: PropTypes.bool,
   micColor: PropTypes.string,
+  focus: PropTypes.bool,
 };
 
 export default MessageComposer;

--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -865,6 +865,7 @@ class MessageSection extends Component {
                 }
                 <div className='compose' style={{backgroundColor:composerColor}}>
                   <MessageComposer
+                    focus={true}
                     threadID={this.state.thread.id}
                     dream={dream}
                     textarea={textArea}
@@ -909,6 +910,17 @@ class MessageSection extends Component {
                    </Scrollbars>
 
                  </ul>
+                 <div className='compose' style={{backgroundColor:composerColor}}>
+                  <MessageComposer
+                    focus={false}
+                    threadID={this.state.thread.id}
+                    dream={dream}
+                    textarea={textArea}
+                    textcolor={textColor}
+                    speechOutput={speechOutput}
+                    speechOutputAlways={speechOutputAlways}
+                    micColor={this.state.button} />
+                </div>
                </div>
              </div>
              )}

--- a/src/components/ChatApp/SearchField.react.js
+++ b/src/components/ChatApp/SearchField.react.js
@@ -124,7 +124,7 @@ class ExpandingSearchField extends Component{
                                 style={textStyle}
                                 value={this.props.searchText}
                                 onChange={(event) => this.onChange(event)}
-                                autoFocus/>
+                                autoFocus={true} />
                                 <IconButton
                                     className='displayNone'
                                     iconStyle={baseStyles.smallIcon}


### PR DESCRIPTION
Fixes issue #823 

Changes:
- Display bottom text field when search is activated 

Demo Link: http://ashamed-care.surge.sh/

Screenshots for the change: 
![screen shot 2017-11-03 at 10 08 24 pm](https://user-images.githubusercontent.com/11137394/32385304-b03b1f76-c0e3-11e7-94a9-b20b7ba5d8e1.png)
