### PR TITLE
Make ajax requests for fetching translated example text  asynchronous

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -499,18 +499,22 @@ export function getTTSLangText(voiceList){
       dataType: 'json',
       crossDomain: true,
       timeout: 3000,
-      async: false,
+      async: true,
+
       success: function (response) {
         if(response[0]){
           if(response[0][0]){
             let translatedText = response[0][0][0];
             voice.translatedText = translatedText;
+            // console.log(url);
           }
         }
       },
+
       error: function(errorThrown){
         console.log(errorThrown);
       }
+
     });
   });
 }


### PR DESCRIPTION
Fixes issue #885 

Changes:
- Make ajax requests for fetching translated example text  asynchronous

Demo Link: http://victorious-run.surge.sh/

Before 
![screen shot 2017-11-04 at 11 09 37 pm](https://user-images.githubusercontent.com/11137394/32407879-43cad408-c1b5-11e7-8b9a-9966111cf8b8.png)
![screen shot 2017-11-04 at 11 11 13 pm](https://user-images.githubusercontent.com/11137394/32407890-7bf7f284-c1b5-11e7-8b19-8862af8676ac.png)

After
![screen shot 2017-11-04 at 11 12 06 pm](https://user-images.githubusercontent.com/11137394/32407904-9f8449fa-c1b5-11e7-9463-399dff443fa3.png)
![screen shot 2017-11-04 at 11 12 11 pm](https://user-images.githubusercontent.com/11137394/32407917-c8772968-c1b5-11e7-9b6d-4cff05b834fd.png)

