### PR TITLE
Disable scroll wheel zoom for map - fix #856

### DIFF
--- a/src/components/ChatApp/MessageListItem/helperFunctions.react.js
+++ b/src/components/ChatApp/MessageListItem/helperFunctions.react.js
@@ -305,14 +305,14 @@ export function drawMap(lat,lng,zoom){
     iconSize: [35, 35]
   });
   const map = (
-   <Map center={position} zoom={zoom}>
+   <Map center={position} zoom={zoom} scrollWheelZoom={false}>
       <TileLayer
         attribution=''
         url='http://{s}.tile.osm.org/{z}/{x}/{y}.png'
       />
       <ExtendedMarker position={position} icon={icon}>
         <Popup>
-          <span><strong>Hello!</strong> <br/> I am here.</span>
+          <span><strong>Here!</strong></span>
         </Popup>
       </ExtendedMarker>
     </Map>


### PR DESCRIPTION
Fixes issue #856 

Changes:
-Disable scroll wheel zoom for the map so it doesn't disturb while scrolling through the conversation, instead, the user can use map controls to zoom.

Demo Link: http://substantial-impulse.surge.sh/

