### PR TITLE
Fixes #903, Removed react-hljs from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react-fittext": "^1.0.0",
     "react-headroom": "^2.1.6",
     "react-highlight": "^0.10.0",
-    "react-hljs": "^1.0.0",
     "react-intl": "^2.3.0",
     "react-leaflet": "^1.1.6",
     "react-linkify": "^0.2.1",


### PR DESCRIPTION
Fixes issue #903 

Changes: **Removed *react-hljs* from dependencies since it is now deprecated.**

Demo: https://fierce-arm.surge.sh/
