### PR TITLE
Fixes #920, Right click won't trigger login button anymore on ForgotPassword component

### DIFF
--- a/src/components/Auth/ForgotPassword/ForgotPassword.react.js
+++ b/src/components/Auth/ForgotPassword/ForgotPassword.react.js
@@ -254,8 +254,8 @@ class ForgotPassword extends Component {
 					</form>
 					{/* Back to Login button */}
 					<RaisedButton
-						onTouchTap={this.props.onLoginSignUp}
-						label={<Translate text='Back to Login'/>}
+						onClick={this.props.onLoginSignUp}
+						label={<Translate text='Login'/>}
 						backgroundColor={
 						UserPreferencesStore.getTheme()==='light'
 						? '#4285f4' : '#19314B'}


### PR DESCRIPTION
Fixes #920 

Changes: Right click won't trigger the login button anymore.

Demo Link: http://susi920.surge.sh/

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/21009455/33227432-d09e783a-d1c8-11e7-869a-365a2ae500eb.png)

