### PR TITLE
Back to Login button fixed in Overview

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -104,7 +104,8 @@ class StaticAppBar extends Component {
         this.setState({
             login: true,
             signup: false,
-            showOptions: false
+            showOptions: false,
+            openForgotPassword: false
         })
         if (this.props.location.pathname === 'overview') {
             this.props.closeVideo();
@@ -465,7 +466,8 @@ class StaticAppBar extends Component {
                     contentStyle={{ width: '35%', minWidth: '300px' }}
                     onRequestClose={this.handleClose}>
                     <ForgotPassword {...this.props}
-                        showForgotPassword={this.showForgotPassword} />
+                        showForgotPassword={this.showForgotPassword}
+                        onLoginSignUp={this.handleLogin} />
                     <Close style={closingStyle}
                         onTouchTap={this.handleClose} />
                 </Dialog>


### PR DESCRIPTION
Fixes issue #911 

Changes:
The login button, on clicking Forgot password in the Overview tab, works properly now.

Demo Link:
http://cynical-paint.surge.sh/

Steps to view the changes:
1. Click on About in the main menu.
2. Then click on Login, and then Forgot Password.
3. Click on the Login button, and it should work properly now.

@mariobehling @rishiraj824 @madhavrathi @isuruAb Please review this ASAP :)
