### PR TITLE
Tabs in settings are correctly titled now

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -780,14 +780,16 @@ class Settings extends Component {
 			currentSetting = '';
 			currentSetting = (
 				<div style={divStyle}>
-					<div style={{
-						marginTop: '10px',
-						'marginBottom': '0px',
-						fontSize: '15px',
-						fontWeight: 'bold'
-					}}>
-						<Translate text="Select Theme" />
-					</div>
+					<span>
+						<div style={{
+							marginTop: '10px',
+							'marginBottom': '0px',
+							fontSize: '15px',
+							fontWeight: 'bold'
+						}}>
+							<Translate text="Select Theme" />
+						</div>
+					</span>
 					<RadioButtonGroup
 						style={{ textAlign: 'left', margin: 20 }}
 						onChange={this.handleSelectChange}
@@ -897,13 +899,15 @@ class Settings extends Component {
 			currentSetting =
 			<div style={divStyle}>
 				<span>
-					<div style={{
-						marginTop: '10px',
-						'marginBottom':'0px',
-						fontSize: '15px',
-						fontWeight: 'bold'}}>
-						<Translate text="Change your Account Password"/>
-					</div>
+					<span>
+						<div style={{
+							marginTop: '10px',
+							'marginBottom':'0px',
+							fontSize: '15px',
+							fontWeight: 'bold'}}>
+							<Translate text="Change your Account Password"/>
+						</div>
+					</span>
 					<ChangePassword settings={this.state.intialSettings} {...this.props} />
 				</span>
 			</div>
@@ -937,15 +941,17 @@ class Settings extends Component {
 			currentSetting = (
 				<span style={divStyle}>
 					<div>
-						<div style={{
-							marginTop: '10px',
-							'marginBottom': '0px',
-							marginLeft: '30px',
-							fontSize: '15px',
-							fontWeight: 'bold'
-						}}>
-							<Translate text="Connect to SUSI Hardware" />
-						</div>
+						<span>
+							<div style={{
+								marginTop: '10px',
+								'marginBottom': '0px',
+								marginLeft: '30px',
+								fontSize: '15px',
+								fontWeight: 'bold'
+							}}>
+								<Translate text="Connect to SUSI Hardware" />
+							</div>
+						</span>
 						<HardwareComponent settings={this.state.intialSettings} {...this.props} />
 					</div>
 				</span>


### PR DESCRIPTION
Fixes issue #873 

Changes:
The titles of some tabs in Settings were not getting changed earlier. Some examples are:
1. Clicking on Account tab after clicking on Password tab or vice versa
2. Clicking on Mobile tab after clicking on Connect to SUSI Hardware tab or vice versa
3. Clicking on ChatApp Settings tab after clicking on Theme tab or vice versa
I've put the titles inside a span element, and now the titles change properly.

Demo Link:  http://dazzling-jellyfish.surge.sh

Please review ASAP :)
