### PR TITLE
Fixes #1007: Removed extra white space on Settings page

### DIFF
--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -82,6 +82,7 @@
 }
 
 .rightMenu {
+  height: 550px;
   width: 64%;
   background-color: #fff;
 }
@@ -127,6 +128,7 @@
 }
 
   .rightMenu {
+    height: 300px;
     width: 100%;
   }
 

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -1201,7 +1201,6 @@ class Settings extends Component {
 		</div>
 
 	 const menuStyle = {
-					 height: 550,
 					 marginTop: 20,
 					 textAlign: 'center',
 					 display: 'inline-block',


### PR DESCRIPTION
Fixes issue #1007

**Changes:**
 1) Removed height of 550px from style of right menu in Settings.react.js.
 2) Added height of 300px under @media constraint for mobile size and 550px otherwise. These changes are made in Settings.css for right menu.



**Demo Link:** https://pr-1012-fossasia-susi-web-chat.surge.sh

**Screenshots:**

![screen shot 2018-01-09 at 4 29 35 pm](https://user-images.githubusercontent.com/13872065/34717896-a7a789f2-f55a-11e7-9ea4-92f86afeda4d.png)
![screen shot 2018-01-09 at 4 30 34 pm](https://user-images.githubusercontent.com/13872065/34717897-a7f621b6-f55a-11e7-9bee-08182855aece.png)
![screen shot 2018-01-09 at 4 31 14 pm](https://user-images.githubusercontent.com/13872065/34717899-a8358bb2-f55a-11e7-8297-f2739be83ffe.png)

  