### PR TITLE
Fixes #1023. Set a default response message for susi when cognition fails.

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -43,7 +43,24 @@ export function getLocation(){
 }
 // Main server call for Creating a SUSI Message
 export function createSUSIMessage(createdMessage, currentThreadID, voice) {
-  var timestamp = Date.now();
+  const timestamp = Date.now();
+  const timezoneOffset = (new Date()).getTimezoneOffset();
+  const defaultAnswer = {
+    data: [{
+      '0': '',
+      timezoneOffset,
+      language: 'en'
+    }],
+    metadata: {
+      count: 1
+    },
+    actions: [{
+      type: 'answer',
+      expression: 'Hmm... I\'m not sure if i understand you correctly.'
+    }],
+    skills: ['/en_0090_fail.json'],
+    persona: {}
+  };
   let receivedMessage = {
     id: 'm_' + timestamp,
     threadID: currentThreadID,
@@ -107,6 +124,12 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
     timeout: 3000,
     async: false,
     success: function (response) {
+      if($.isEmptyObject(response.answers)) {
+        // Susi server sets response.answers as an empty array if cognition
+        // is unsuccessful, example in case of gibberish text query
+        response.answers.push(defaultAnswer);
+      }
+
       // send susi response to connected Hardware Device
       Actions.sendToHardwareDevice(response);
 


### PR DESCRIPTION
Fixes issue #1023.

Changes: Set a default response message for susi instead of displaying an infinitely loading gif as a chat message by modifying the ajax call to susi server.

Demo Link: https://pr-1024-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/20877996/34763515-82cb7afa-f611-11e7-9585-6cb74bf0e080.png)
