### PR TITLE
Solve header bar issue in dark theme in settings

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -402,7 +402,7 @@ class StaticAppBar extends Component {
         const themeBackgroundColor = this.props.settings && this.props.settings.theme==='dark'?'rgb(25, 50, 76)':'#4285f4';
         return (
             <div>
-                <header className="nav-down" >
+                <header className="nav-down" style={{backgroundColor: themeBackgroundColor}}>
                     <AppBar
                         id="headerSection"
                         className="topAppBar"


### PR DESCRIPTION
Fixes #1025 

Changes: Added dark theme style in header of settings.

Screenshots for the change: 

Before-
<img width="600" alt="screen shot 2018-01-10 at 10 28 30 pm" src="https://user-images.githubusercontent.com/31174685/34785547-7da229fc-f657-11e7-9fc6-4ac246c44b05.png">

After-
<img width="600" alt="screen shot 2018-01-10 at 10 33 09 pm" src="https://user-images.githubusercontent.com/31174685/34785569-8a39c33c-f657-11e7-9f2b-fdd71aba0e07.png">
