### PR TITLE
Fix menu dimension issue in settings

### DIFF
--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -106,7 +106,7 @@
 }
 
 
-@media only screen and (max-width: 1000px){
+@media only screen and (max-width: 1060px){
   .settings-list-dropdown{
     display: inline-block;
   }


### PR DESCRIPTION
Fixes #1037 

Changes: The Menu options style was getting changed to dropdown after screen got smaller than 1000px horizontally. Now the limit is 1060px.

Demo Link: http://secretive-spot.surge.sh/

Screenshots for the change: 

Before- (Between 1000px to 1060px horizontally)
<img width="895" alt="34905072-5401e7c8-f877-11e7-97dd-d4230099deb2" src="https://user-images.githubusercontent.com/31174685/34907223-30a072f2-f8a1-11e7-8810-d26950f28690.png">


Now it'll get changed to dropdown after this point - (at 1060px horizontally)
<img width="935" alt="screen shot 2018-01-13 at 3 50 52 pm" src="https://user-images.githubusercontent.com/31174685/34905175-9ff35a16-f879-11e7-9672-0aa797d5ce5a.png">

