### PR TITLE
Fix text fit issue in settings

### DIFF
--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -128,7 +128,7 @@
 }
 
   .rightMenu {
-    height: 300px;
+    height: 480px;
     width: 100%;
   }
 


### PR DESCRIPTION
Fixes #1039

Changes: Changed the height of the box enough so that it can fit all the text properly.

Demo Link: http://living-condition.surge.sh/

Screenshots for the change: 

Before-
<img width="368" alt="screen shot 2018-01-13 at 3 58 10 pm" src="https://user-images.githubusercontent.com/31174685/34905357-fe039078-f87c-11e7-84ac-905d3fafe1ab.png">

After-
<img width="351" alt="screen shot 2018-01-13 at 4 03 15 pm" src="https://user-images.githubusercontent.com/31174685/34905358-02d82564-f87d-11e7-8c18-25336272d244.png">


