### PR TITLE
Parallelize the travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,19 @@ language: node_js
 node_js:
   - 6
 
-script:
-  - npm test
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-  - bash ./surge_deploy.sh
-  - bash ./deploy.sh
-
 cache:
   directories:
     - node_modules
 
-branches:
-  only:
-    - master
+matrix:
+  include:
+    # Run npm tests and get code coverage matrix
+    - script:
+      - npm test
+      - bash <(curl -s https://codecov.io/bash)
+
+    # Deploy PR to surge
+    - script: bash ./surge_deploy.sh
+
+    # Deploy on non-prs
+    - script: bash ./deploy.sh


### PR DESCRIPTION
Parallelizes the travis ci build into multiple vm instances.
The instances are:
- Testing and getting code coverage matrix
- Deploying pr to surge
- Deploying non-prs

Also added functionality to build from all branches.

Fixes #1051

Demo Link: See the travis ci build (https://travis-ci.org/fossasia/chat.susi.ai/builds/328650006)
