### PR TITLE
Fixed issue with share on social media in settings

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -1127,7 +1127,7 @@ class Settings extends Component {
 			<hr className="break-line"/>
 			<MenuItem style={{color:themeForegroundColor}} value='Mobile' className="setting-item" leftIcon={<MobileIcon color={menuIconColor} />}>Mobile<ChevronRight style={{color:themeForegroundColor}} className="right-chevron" /></MenuItem>
 			<hr className="break-line"/>
-			<MenuItem style={{color:themeForegroundColor}} value='Share on Social media' className="setting-item" leftIcon={<ShareIcon color={menuIconColor}/>}>SShare on Social media<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
+			<MenuItem style={{color:themeForegroundColor}} value='Share on Social media' className="setting-item" leftIcon={<ShareIcon color={menuIconColor}/>}>Share on Social media<ChevronRight style={{color:themeForegroundColor}} className="right-chevron"/></MenuItem>
 		</Menu>
 		</div>
 		<div className="settings-list-dropdown">


### PR DESCRIPTION
Fixes #1067 
Fixes #1068 

Changes: Simply corrected spelling.
Now the "Share on social media" option is working.

Demo Link: http://selfish-curtain.surge.sh/settings (Please login to see changes)

Screenshots for the change: 
<img width="478" alt="screen shot 2018-01-26 at 7 19 36 pm" src="https://user-images.githubusercontent.com/31174685/35442641-fd3c9cce-02cd-11e8-8a05-d49969a9b7b7.png">

<img width="700" alt="screen shot 2018-01-26 at 7 19 41 pm" src="https://user-images.githubusercontent.com/31174685/35442650-00d2656c-02ce-11e8-885b-7ec55c60d971.png">


