### PR TITLE
Removing heading general from text to speech settings

### DIFF
--- a/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
+++ b/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
@@ -190,6 +190,7 @@ class TextToSpeechSettings extends Component {
 								label={<Translate text="Play Demonstration"/>}
 								onClick={this.playDemo} />
 					</div>
+				</Paper>
 				{ this.state.playExample &&
 	               (<VoicePlayer
 	                  play={this.state.play}

--- a/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
+++ b/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
@@ -135,25 +135,19 @@ class TextToSpeechSettings extends Component {
 			marginBottom: 16,
 		}
 
-		const subHeaderStyle = {
-			color: UserPreferencesStore.getTheme()==='light'
-								? '#4285f4' : '#19314B'
-		}
-
 		let voiceOutput = this.populateVoiceList();
 
 		return (
 			<div className="settingsForm">
 				<Paper zDepth={0}>
 					<h3 style={{textAlign: 'center'}}><Translate text="Text-To-Speech Settings"/></h3>
-					<h4 style={subHeaderStyle}><Translate text="General"/></h4>
 							<div>
 								<h4 style={{'marginBottom':'0px'}}><Translate text="Language"/></h4>
 								<DropDownMenu
 									value={voiceOutput.voiceLang}
 									onChange={this.handleTTSVoices}>
 								 {voiceOutput.voiceMenu}
-							 </DropDownMenu>
+							 	</DropDownMenu>
 							</div>
 			        <div>
 			        	<h4 style={{'marginBottom':'0px'}}><Translate text="Speech Rate"/></h4>


### PR DESCRIPTION
Fixes #1069 

Changes: Removed the heading "General" from the "Text-To-Speech" Settings.
To know why I did this, please refer the issue #1069 . I have properly written the purpose of this there.

Demo Link: http://salty-cabbage.surge.sh/

Screenshots for the change: 

Before-
<img width="686" alt="screen shot 2018-01-29 at 11 46 01 pm" src="https://user-images.githubusercontent.com/31174685/35526790-9ef38280-054e-11e8-82df-07585363f7f1.png">

After-
<img width="665" alt="screen shot 2018-01-29 at 11 45 13 pm" src="https://user-images.githubusercontent.com/31174685/35526797-a25eeefa-054e-11e8-99e8-ce4eebefdc07.png">
