### PR TITLE
Correct spacing between options under reset password menu

### DIFF
--- a/src/components/Auth/ChangePassword/ChangePassword.react.js
+++ b/src/components/Auth/ChangePassword/ChangePassword.react.js
@@ -302,9 +302,7 @@ export default class ChangePassword extends Component {
                                 floatingLabelText={<Translate text="New Password" />} />
                               <div className="ReactPasswordStrength-strength-bar" />
                               <div>
-                                <p>
                                   {this.state.newPasswordStrength}
-                                </p>
                               </div>
                         </div>
                         <div>
@@ -322,6 +320,7 @@ export default class ChangePassword extends Component {
                                 floatingLabelText={<Translate text="Confirm New Password" />} />
                         </div>
                         <div>
+                            <br />
                             <RaisedButton
                                 label={<Translate text="Change" />}
                                 type="submit"


### PR DESCRIPTION
Fixes #1080 

Demo Link: http://frightening-fowl.surge.sh/

Screenshots for the change: 

Before-
<img width="295" alt="screen shot 2018-01-30 at 12 11 28 am" src="https://user-images.githubusercontent.com/31174685/35527882-29b85d16-0552-11e8-9958-c09a26bf2c6a.png">

After-
<img width="297" alt="screen shot 2018-01-30 at 12 02 44 am" src="https://user-images.githubusercontent.com/31174685/35527889-2d58c3f2-0552-11e8-890f-52173ea52503.png">
