### PR TITLE
changed text color to white in dark theme and font size to 15px

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -387,7 +387,7 @@ header{
 .dark .message-container.SUSI{
   border-color:rgba(25, 147, 147, 0.2);
   background:rgba(25, 147, 147, 0.2);
-  color: #0EC879;
+  color: #fff;
 }
 
 .message-container.You{
@@ -397,7 +397,7 @@ header{
 
 .dark .message-container.You{
   background: rgba(25, 147, 147, 0.2);
-  color: #0AD5C1;
+  color: #fff;
 }
 
 .message-container.SUSI>h5,.message-container.SUSI>.message-text {
@@ -444,7 +444,7 @@ header{
 }
 
 .message-text, .thread-last-message {
-  font-size: 14px;
+  font-size: 15px;
   margin: 0;
   padding: 0;
   overflow-wrap: break-word;
@@ -522,7 +522,7 @@ header{
 }
 
 .dark .message-composer textarea{
-  color: #0AD5C1;
+  color: #fff;
   background: rgba(0, 0, 0, 0.01);
 }
 .textBack {


### PR DESCRIPTION
Fixes #1092 

Changes: 
changed the colour of text in chat box to white and font to 15px .

Demo Link: comming

Screenshots for the change: 
Now
![screenshot from 2018-02-04 11-39-06](https://user-images.githubusercontent.com/26831659/35774861-24f29e32-09a2-11e8-9a9e-90d3f9590cfa.png)
previously
![screenshot from 2018-02-04 11-41-01](https://user-images.githubusercontent.com/26831659/35774862-263b5252-09a2-11e8-9f17-13dad5ff7b97.png)
