### PR TITLE
Solve toggle switch issue in settings

### DIFF
--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -36,13 +36,13 @@
 }
 
 .settingsBtns {
-  top: 10px;
-  margin-left: 30px ;
+  top: 5px;
+  margin-left: 20px ;
 }
 
 .settings-toggle {
-  padding: 20px;
-  max-width: 60%;
+  max-width: 5%;
+  float: left;
 }
 
 .settingsSubmit{

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -785,14 +785,20 @@ class Settings extends Component {
 								fontWeight: 'bold'
 							}}>
 								<Translate text="Mic Input" />
+							</div><br />
+							<div style={{
+								float: 'left',
+								padding: '0px 5px 0px 0px'
+							}}>
+								<Translate text="Enable mic to give voice input "/>
 							</div>
 							<Toggle
 								className='settings-toggle'
-								label={<Translate text="Enable mic to give voice input"/>}
 								labelStyle={{color:themeForegroundColor}}
 								disabled={!this.STTBrowserSupport}
 								onToggle={this.handleMicInput}
 								toggled={this.state.micInput} />
+							<br />
 						</div>
 					</div>
 				</div>
@@ -861,14 +867,20 @@ class Settings extends Component {
 										fontSize: '15px',
 										fontWeight: 'bold'}}>
 										<Translate text="Speech Output"/>
+									</div><br />
+									<div style={{
+										float: 'left',
+										padding: '0px 5px 0px 0px'
+									}}>
+										<Translate text="Enable speech output only for speech input"/>
 									</div>
 									<Toggle
 										className='settings-toggle'
-										label={<Translate text="Enable speech output only for speech input"/>}
 										disabled={!this.TTSBrowserSupport}
 										labelStyle={{color:themeForegroundColor}}
 										onToggle={this.handleSpeechOutput}
 										toggled={this.state.speechOutput}/>
+									<br /><br />
 								</div>
 								<div>
 									<div style={{
@@ -877,14 +889,20 @@ class Settings extends Component {
 										fontSize: '15px',
 										fontWeight: 'bold'}}>
 										<Translate text="Speech Output Always ON"/>
+									</div><br />
+									<div style={{
+										float: 'left',
+										padding: '5px 5px 0px 0px'
+									}}>
+										<Translate text="Enable speech output regardless of input type"/>
 									</div>
 									<Toggle
 										className='settings-toggle'
-										label={<Translate text="Enable speech output regardless of input type"/>}
 										disabled={!this.TTSBrowserSupport}
 										labelStyle={{color:themeForegroundColor}}
 										onToggle={this.handleSpeechOutputAlways}
 										toggled={this.state.speechOutputAlways}/>
+									<br /><br />
 								</div>
 								<div>
 									<div style={{
@@ -1088,13 +1106,19 @@ class Settings extends Component {
 						fontWeight: 'bold'
 					}}>
 						<Translate text="Preferences" />
+					</div><br />
+					<div style={{
+						float: 'left',
+						padding: '0px 5px 0px 0px'
+					}}>
+						<Translate text="Send message by pressing ENTER" />
 					</div>
 					<Toggle
 						className='settings-toggle'
-						label={<Translate text="Send message by pressing ENTER" />}
 						onToggle={this.handleEnterAsSend}
 						labelStyle={{color:themeForegroundColor}}
 						toggled={this.state.enterAsSend}/>
+					<br />
 				</div>);
 		}
 		let blueThemeColor={color: 'rgb(66, 133, 244)'};


### PR DESCRIPTION
Fixes #1070

Changes: Now switch will be toggled only when we click on the switch and not when we click on the text.(Please refer issue)

Demo Link: http://burly-hole.surge.sh/
Open this link and go to settings.
The toggle switches in menus "ChatApp Settings", "Mic Settings" and "Speech settings" are now triggered only when we click on the switch and not when we click on the text with it.

