### PR TITLE
Changes color scheme of chat messages for Dark Theme

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -363,7 +363,7 @@ header{
 
 .dark .container-date{
   background: rgba(25, 147, 147, 0.2);
-  color: #0AD5C1;
+  color: #FFFFFF;
   position: relative;
   min-width: 80px;
   max-width: 80%;
@@ -387,7 +387,7 @@ header{
 .dark .message-container.SUSI{
   border-color:rgba(25, 147, 147, 0.2);
   background:rgba(25, 147, 147, 0.2);
-  color: #0EC879;
+  color: #FFFFFF;
 }
 
 .message-container.You{
@@ -397,7 +397,7 @@ header{
 
 .dark .message-container.You{
   background: rgba(25, 147, 147, 0.2);
-  color: #0AD5C1;
+  color: #FFFFFF;
 }
 
 .message-container.SUSI>h5,.message-container.SUSI>.message-text {
@@ -484,7 +484,7 @@ header{
 
 .dark .compose{
   background: rgba(30, 87, 153, 0.02);
-  color: #0AD5C1;
+  color: #FFFFFF;
 }
 
 .scrollBottom{
@@ -522,7 +522,7 @@ header{
 }
 
 .dark .message-composer textarea{
-  color: #0AD5C1;
+  color: #FFFFFF;
   background: rgba(0, 0, 0, 0.01);
 }
 .textBack {
@@ -731,7 +731,7 @@ textarea {
 }
 
 .dark a{
-  color: #80a9a5;
+  color: #0ad5c1;
 }
 
 .theme-button{


### PR DESCRIPTION
Fixes #1102 

**Changes:** Changed the color scheme of the chat messages so as to improve readability in Dark Theme.

**Demo Link:** https://pr-1102-fossasia-susi-web-chat.surge.sh

**Screenshots for the change:**

**Current state:**
![original](https://user-images.githubusercontent.com/31135861/36426723-0d1e14fe-1671-11e8-9255-fb3b50b51ac1.png)

**Updated state:**
![new](https://user-images.githubusercontent.com/31135861/36426767-357aeb5c-1671-11e8-9073-e71f6eb3b63d.png)

