### PR TITLE
encode users query - fix #1104

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -82,12 +82,12 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
   if(cookies.get('loggedIn')===null||
     cookies.get('loggedIn')===undefined) {
     url = BASE_URL+'/susi/chat.json?q='+
-          createdMessage.text+
+          encodeURIComponent(createdMessage.text)+
           '&language='+locale;
   }
   else{
     url = BASE_URL+'/susi/chat.json?q='
-          +createdMessage.text+'&language='
+          +encodeURIComponent(createdMessage.text)+'&language='
           +locale+'&access_token='
           +cookies.get('loggedIn');
   }
@@ -95,7 +95,6 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
   if(_Location){
     url += '&latitude='+_Location.lat+'&longitude='+_Location.lng;
   }
-
   // Ajax Success calls the Dispatcher to CREATE_SUSI_MESSAGE only when the User is online
   if(!offlineMessage){
   $.ajax({


### PR DESCRIPTION
Fixes #1104 

Changes: encode user's query by using `encodeURIComponent` built-in function

Demo Link: https://pr-1105-fossasia-susi-web-chat.surge.sh

Before:
![image](https://user-images.githubusercontent.com/17807257/36631147-a90e9daa-1998-11e8-8d16-ae7e11fb6d18.png)
![image](https://user-images.githubusercontent.com/17807257/36631152-bffeea88-1998-11e8-90ed-4872b12c91b4.png)

After:
![image](https://user-images.githubusercontent.com/17807257/36631149-af659384-1998-11e8-94ea-d6590cfea667.png)
![image](https://user-images.githubusercontent.com/17807257/36631151-bbbb754a-1998-11e8-9830-16c40f538619.png)

