### PR TITLE
Changes colour of Forgot Password Text

### DIFF
--- a/src/components/Auth/Login/Login.css
+++ b/src/components/Auth/Login/Login.css
@@ -3,7 +3,7 @@
 	cursor: pointer;
 }
 .forgotpwdlink:hover{	
-    color: #039be5;
+    color: red;
 }
 .loginForm{
 	margin: 0 auto;


### PR DESCRIPTION
Fixes #1108 

**Changes:** Changed the colour of the Forgot Password text. I think "red" colour suits better.

**Demo Link:** https://pr-1108-fossasia-susi-web-chat.surge.sh

**Screenshots for the change:**

**Current state:**
![forgotpwdold](https://user-images.githubusercontent.com/31135861/36835511-7a47b39a-1d5c-11e8-8ccc-7826c0916039.png)


**Updated state:**

![forgotpwdnew](https://user-images.githubusercontent.com/31135861/36835520-83d9fdaa-1d5c-11e8-99e3-7615b67a416c.png)


