### PR TITLE
Solves inconsistent indentation of message date in Light and Dark theme

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -439,7 +439,7 @@ header{
 .dark .message-time, .thread-time{
   float: right;
   color: #7eaaaf;
-  margin: 7px 15px -7px 0;
+  margin: 3px 0px -3px -38px;
 
 }
 


### PR DESCRIPTION
Fixes #1120 

**Changes:** Currently, the date has more indentation space in the dark theme than in the light theme.

![datelighttheme](https://user-images.githubusercontent.com/31135861/36923502-8788593e-1e91-11e8-8027-b47480fdb4bf.png)

![datedarktheme](https://user-images.githubusercontent.com/31135861/36923515-8b79bef2-1e91-11e8-8c8b-9821f2fef467.png)

This PR solves this inconsistency.

**Demo Link:** https://pr-1120-fossasia-susi-web-chat.surge.sh

**Screenshots for the change:** 

The inconsistency is solved.

![fixedindentlight](https://user-images.githubusercontent.com/31135861/36926208-8759af34-1e9c-11e8-98de-e9350fcc2576.png)

![fixedindentdark](https://user-images.githubusercontent.com/31135861/36926217-8e49aac4-1e9c-11e8-8948-e589d51d924c.png)

