### PR TITLE
Live Theme preview 

### DIFF
--- a/src/stores/UserPreferencesStore.js
+++ b/src/stores/UserPreferencesStore.js
@@ -7,6 +7,7 @@ let CHANGE_EVENT = 'change';
 
 let _defaults = {
     Theme: 'light',
+    PreviewTheme: 'light',
     Server: 'https://api.susi.ai',
     StandardServer: 'https://api.susi.ai',
     EnterAsSend: true,
@@ -37,11 +38,9 @@ let UserPreferencesStore = {
     getPreferences() {
         return _defaults;
     },
-
-    getTheme(){
-        return _defaults.Theme;
+    getTheme(preview = false){
+	return (preview === false)? _defaults.Theme:_defaults.PreviewTheme;
     },
-
     getThemeValues(){
         return _defaults.ThemeValues;
     },
@@ -121,6 +120,9 @@ UserPreferencesStore.dispatchToken = ChatAppDispatcher.register(action => {
             if(settings.hasOwnProperty('theme')){
                     _defaults.Theme = settings.theme;
             }
+            if(settings.hasOwnProperty('previewTheme')){
+                    _defaults.PreviewTheme = settings.previewTheme;
+            }
             if(settings.hasOwnProperty('enterAsSend')){
                 _defaults.EnterAsSend = checkForFalse(settings.enterAsSend);
             }
@@ -182,6 +184,7 @@ UserPreferencesStore.dispatchToken = ChatAppDispatcher.register(action => {
             let settings = action.settings;
             if(settings.hasOwnProperty('LocalStorage')){
                 _defaults.Theme = settings.theme;
+		_defaults.PreviewTheme = settings.previewTheme;
                 _defaults.EnterAsSend = settings.enterAsSend;
                 _defaults.MicInput = settings.micInput;
                 _defaults.SpeechOutput = settings.speechOutput;
@@ -200,6 +203,9 @@ UserPreferencesStore.dispatchToken = ChatAppDispatcher.register(action => {
             else{
                 if(settings.hasOwnProperty('theme')){
                     _defaults.Theme = settings.theme;
+                }
+                if(settings.hasOwnProperty('previewTheme')){
+                    _defaults.PreviewTheme = settings.previewTheme;
                 }
                 if(settings.hasOwnProperty('enterAsSend')){
                     _defaults.EnterAsSend = checkForFalse(settings.enterAsSend);


### PR DESCRIPTION
Fixes #1107 

Changes: Added functionality for theme preview as soon as the user selects a 
theme, and reverts back to last saved theme if the setting are not saved.
Implemented by saving the state of current theme into original Theme variable, 
and changing it only when user saves settings.

Demo Link: https://theme-preview.surge.sh

Screenshots for the change: 
![screenshot from 2018-03-05 06-31-38](https://user-images.githubusercontent.com/23399264/36953842-7fe44db4-203f-11e8-9dfc-bb6b4d789640.png)
![screenshot from 2018-03-05 06-31-15](https://user-images.githubusercontent.com/23399264/36953846-827fa6fe-203f-11e8-95d3-0682a9406ca4.png)
