### PR TITLE
Added theme option when not logged in on chat window

### DIFF
--- a/src/components/ChatApp/TopBar.react.js
+++ b/src/components/ChatApp/TopBar.react.js
@@ -146,6 +146,10 @@ class TopBar extends Component {
 					<MenuItem primaryText={<Translate text="Settings"/>}
 						containerElement={<Link to="/settings" />}
 						rightIcon={<Settings/>} />
+						<MenuItem primaryText={<Translate text="Themes"/>}
+						key="custom"
+						onClick={this.props.handleThemeChanger}
+						rightIcon={<Edit/>}/>
 					<MenuItem primaryText={<Translate text="Login"/>}
 						onTouchTap={this.props.handleOpen}
 					rightIcon={<SignUp/>} />


### PR DESCRIPTION
Fixes #1134 

Changes: 
Added theme option when not logged in on chat window.
Demo Link: http://add-theme.surge.sh/
Screenshots for the change: 
Before:-
![screen shot 2018-03-06 at 12 34 56 am](https://user-images.githubusercontent.com/31013104/36994094-0978480a-20d6-11e8-99d7-0c349018cb21.png)
After:
![screen shot 2018-03-06 at 12 35 14 am](https://user-images.githubusercontent.com/31013104/36994107-11f6158e-20d6-11e8-804a-c6706e3be5ca.png)
