### PR TITLE
Fix issue with code blocks and title on blog page

### DIFF
--- a/src/components/Blog/Blog.css
+++ b/src/components/Blog/Blog.css
@@ -154,6 +154,13 @@ pre{
     word-wrap: break-word;
     white-space: pre;
     font-size: 16px;
+	display :block;
+}
+table{
+	display : block;
+	overflow-x: auto;
+	white-space: nowrap;
+	
 }
 @media only screen and (min-width: 1400px){
     .blog_navigation {


### PR DESCRIPTION
Fixes #1112 
Fixes #1117 
Changes:Made code blocks width responsive 

Demo Link: http://pale-plant.surge.sh/

Screenshots for the change: 
Before:
![codeblocks](https://user-images.githubusercontent.com/30981465/37079672-64168b26-2209-11e8-85de-069f6eb3905f.png)

Now:
![codeblocks1](https://user-images.githubusercontent.com/30981465/37079685-731f8636-2209-11e8-834d-1819b2ae1158.png)


