### PR TITLE
Removes horizontal scrollbar from the iframe

### DIFF
--- a/src/components/ChatApp/MessageSection/DialogSection.js
+++ b/src/components/ChatApp/MessageSection/DialogSection.js
@@ -94,6 +94,8 @@ export default class DialogSection extends Component {
 						src="https://www.youtube.com/embed/9T3iMoAUKYA"
 						gesture="media"
 						allow="encrypted-media"
+						frameBorder="0"
+ 						scrolling="no"
 						>
 					</iframe>
 					<Close style={closingStyle} onTouchTap={this.props.onRequestCloseTour()} />


### PR DESCRIPTION
Fixes #1143 

**Changes:** Removes the horizontal scrollbar from the iframe that loads at the starting of the website using JavaScript so that it still renders perfectly on all browsers.

**Demo Link:** https://pr-1143-fossasia-susi-web-chat.surge.sh

**Screenshots for the change:** 

**Current state:**
![scrollbarold](https://user-images.githubusercontent.com/31135861/37188013-1248035e-2373-11e8-963e-6f3de1e8686c.png)

**Updated state:**
![scrollbarnew](https://user-images.githubusercontent.com/31135861/37188018-188e78d8-2373-11e8-9e5c-8c2dccea4819.png)

