### PR TITLE
Default message for empty responses. Fix #1150

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -12,6 +12,7 @@ const cookies = new Cookies();
 let ActionTypes = ChatConstants.ActionTypes;
 let _Location = null;
 let offlineMessage = null;
+let defaultMessage = 'Sorry, I could not understand what you just said.';
 
 // Handle offline, online events
 window.addEventListener('offline', handleOffline.bind(this));
@@ -109,8 +110,28 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
     success: function (response) {
       // send susi response to connected Hardware Device
       Actions.sendToHardwareDevice(response);
-
+      // Trying for empty response i.e no answer returned
+      try{
       receivedMessage.text = response.answers[0].actions[0].expression;
+      	}
+      catch (err) {
+      	if (err instanceof TypeError) {
+      		let emptyData = [];
+      		emptyData[0] = [];
+      		emptyData[1] = {};
+      		response.answers = [];
+      		response.answers[0] = {
+      			actions: [],
+      			data:emptyData,
+      		};
+      		response.answers[0].actions[0] = {
+      			expression:defaultMessage,
+      			language:'en',
+      			type:'answer',
+      		   		   	};
+        	receivedMessage.text = response.answers[0].actions[0].expression;
+    	}
+      }
       if(receivedMessage.lang===undefined){
         receivedMessage.lang = document.documentElement.getAttribute('lang');
       }
@@ -224,13 +245,14 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
             type: ActionTypes.CREATE_SUSI_MESSAGE,
             message
           });
+
         }
         else{
           previewURLForImage(receivedMessage,currentThreadID,
                               BASE_URL,data,count,remainingDataIndices,0,0);
         }
       }
-      else {
+      else  {
         let message = ChatMessageUtils.getSUSIMessageData(
           receivedMessage, currentThreadID);
         ChatAppDispatcher.dispatch({
@@ -240,7 +262,6 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
       }
     },
     error: function (xhr, status, error) {
-      console.log(receivedMessage.text);
       if (status === 'timeout') {
         receivedMessage.text = 'Please check your internet connection';
       }


### PR DESCRIPTION
Added a default message that is displayed when response of
query is empty, i.e answer was not generated (processed).

Fixes #1150 

Changes: IN  src/actions/API.actions.js :  Added default error message to 
server as response when and empty response is received from server.

Demo Link: http://susi-defaultmsg.surge.sh/

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/23399264/37305694-2a02dbfe-2657-11e8-99c0-30f04761b859.png)
