### PR TITLE
Adds control to the enlargement of the message composer.

### DIFF
--- a/src/components/ChatApp/MessageComposer.react.js
+++ b/src/components/ChatApp/MessageComposer.react.js
@@ -212,7 +212,7 @@ class MessageComposer extends Component {
             className='scroll'
             id='scroll'
             minRows={1}
-            maxRows={5}
+            maxRows={2}
             placeholder="Type a message..."
             value={this.state.text}
             onChange={this._onChange.bind(this)}
@@ -374,7 +374,7 @@ MessageComposer.propTypes = {
   speechOutput: PropTypes.bool,
   speechOutputAlways: PropTypes.bool,
   micColor: PropTypes.string,
-  focus: PropTypes.bool,
+  focus: PropTypes.bool
 };
 
 export default MessageComposer;


### PR DESCRIPTION
Fixes #1154 

Changes: The maximum limit of the message composer box was reduced and now no overlapping takes place

Demo Link: annoying-knee.surge.sh

Screenshots for the change: 
<img width="1240" alt="screen shot 2018-03-17 at 1 06 14 pm" src="https://user-images.githubusercontent.com/29942790/37552926-205ef58e-29e4-11e8-8aa8-fab504c06e70.png">

