### PR TITLE
Change the max width limit for search option that causes image to disappear to 460px

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -811,7 +811,7 @@ abbr[title] {
   color: #001d38;
 }
 
-@media only screen and (max-width: 860px){
+@media only screen and (max-width: 560px){
   .app-bar-search img {
     display: none !important;
   }


### PR DESCRIPTION
Fixes #1173 

Changes: Changed the max width limit for search option, that causes image to disappear, to 460px. I changed it from 860px to 460px because at 860px the browser was wide enough to accommodate both SUSI.AI logo and search bar. Please have a look at issue for screenshot of that.

Screenshots for the change: 

When width is greater than 460px (around 462px in this screenshot) -
<img width="462" alt="screen shot 2018-04-30 at 7 10 25 pm" src="https://user-images.githubusercontent.com/31174685/39430366-4ae72f44-4cab-11e8-8b34-0264c8a400f4.png">

<img width="463" alt="screen shot 2018-04-30 at 7 10 43 pm" src="https://user-images.githubusercontent.com/31174685/39430369-4ce284e2-4cab-11e8-98bb-042b4c2d64ba.png">

When width is less than 460px(around 420px in this screenshot) -
<img width="420" alt="screen shot 2018-04-30 at 7 11 25 pm" src="https://user-images.githubusercontent.com/31174685/39430409-654e727a-4cab-11e8-9722-fd9e66b9224d.png">

<img width="417" alt="screen shot 2018-04-30 at 7 11 36 pm" src="https://user-images.githubusercontent.com/31174685/39430413-66f05c7e-4cab-11e8-8cd2-ee1b965c03d1.png">



