### PR TITLE
Centres the welcome text

### DIFF
--- a/src/components/ChatApp/MessageSection/DialogSection.js
+++ b/src/components/ChatApp/MessageSection/DialogSection.js
@@ -84,8 +84,8 @@ export default class DialogSection extends Component {
 				</Dialog>
 				<Dialog
           className='dialogStyle'
-					contentStyle={{ width: '45%', minWidth: '300px'}}
-          title="Welcome to SUSI Web Chat"
+					contentStyle={{ width: '45%', minWidth: '300px', textAlign: 'center'}}
+          title="Welcome to SUSI Web Chat !!"
 					open={this.props.tour}
 				>
 					<iframe

--- a/src/components/ChatApp/MessageSection/DialogSection.js
+++ b/src/components/ChatApp/MessageSection/DialogSection.js
@@ -85,7 +85,7 @@ export default class DialogSection extends Component {
 				<Dialog
           className='dialogStyle'
 					contentStyle={{ width: '45%', minWidth: '300px', textAlign: 'center'}}
-          title="Welcome to SUSI Web Chat !!"
+          title="Welcome to SUSI.AI Web Chat"
 					open={this.props.tour}
 				>
 					<iframe


### PR DESCRIPTION
Fixes #1187 

**Changes:** Centred the welcome text because it looks better when it is centred in the dialog box that pops up at the starting of the webpage.

**Demo Link:** https://pr-1187-fossasia-susi-web-chat.surge.sh