### PR TITLE
Removes the by default keyboard focus on the Reset Button

### DIFF
--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -792,7 +792,7 @@ class MessageSection extends Component {
       backgroundColor={buttonColor?buttonColor:'#4285f4'}
       labelColor="#fff"
       width='200px'
-      keyboardFocused={true}
+      keyboardFocused={false}
       onTouchTap={this.saveThemeSettings}
       style={{margin:'0 5px'}}
     />
@@ -801,7 +801,7 @@ class MessageSection extends Component {
       backgroundColor={buttonColor?buttonColor:'#4285f4'}
       labelColor="#fff"
       width='200px'
-      keyboardFocused={true}
+      keyboardFocused={false}
       onTouchTap={this.handleRestoreDefaultThemeClick}
       style={{margin:'0 5px'}}
     />


### PR DESCRIPTION
Fixes #1194 

**Changes:** Changed the by default keyboard focus state of Save and Reset button so that they are not in focus by default.
