### PR TITLE
Add Botbuilder to the Hamburger menu

### DIFF
--- a/src/components/ChatApp/TopBar.react.js
+++ b/src/components/ChatApp/TopBar.react.js
@@ -18,6 +18,7 @@ import susiWhite from '../../images/susi-logo-white.png';
 import Info from 'material-ui/svg-icons/action/info';
 import Dashboard from 'material-ui/svg-icons/action/dashboard';
 import Chat from 'material-ui/svg-icons/communication/chat';
+import Extension from 'material-ui/svg-icons/action/extension';
 import Translate from '../Translate/Translate.react';
 
 const cookies = new Cookies();
@@ -96,13 +97,18 @@ class TopBar extends Component {
 						href="https://skills.susi.ai"
 					><Translate text="Skills"/>
 					</MenuItem>
-					<MenuItem primaryText={<Translate text="Settings"/>}
-						containerElement={<Link to="/settings" />}
-						rightIcon={<Settings/>}/>
 					<MenuItem primaryText={<Translate text="Themes"/>}
 						key="custom"
 						onClick={this.props.handleThemeChanger}
 						rightIcon={<Edit/>}/>
+					<MenuItem
+						rightIcon={<Extension/>}
+						href="https://skills.susi.ai/botbuilder"
+					><Translate text="Botbuilder"/>
+					</MenuItem>
+					<MenuItem primaryText={<Translate text="Settings"/>}
+						containerElement={<Link to="/settings" />}
+						rightIcon={<Settings/>}/>
 					<MenuItem primaryText={<Translate text="Logout"/>}
 						containerElement={<Link to="/logout" />}
 						rightIcon={<Exit />}/>


### PR DESCRIPTION
Related #1241 

Changes: Add botbuilder to dropdown menu, moved theme above settings.

Demo Link: https://pr-1247-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/21009455/40572679-d644944a-60cf-11e8-8a14-3070faaa2e2b.png)

PS: The botbuilder route will work when https://github.com/fossasia/susi_skill_cms/pull/497 is merged.