### PR TITLE
Speeds up the Drop-Down Menu Animation

### DIFF
--- a/src/components/ChatApp/TopBar.react.js
+++ b/src/components/ChatApp/TopBar.react.js
@@ -77,6 +77,7 @@ class TopBar extends Component {
 				</IconButton>
 				<Popover
 					{...props}
+					animated={false}
 					style={{marginLeft:'-25px'}}
 					open={this.state.showOptions}
 					anchorEl={this.state.anchorEl}
@@ -129,6 +130,7 @@ class TopBar extends Component {
 				</IconButton>
 				<Popover
 					{...props}
+					animated={false}
 					style={{marginLeft:'-25px'}}
 					open={this.state.showOptions}
 					anchorEl={this.state.anchorEl}
@@ -230,6 +232,7 @@ class TopBar extends Component {
 								<MoreVertIcon />
 							</IconButton>
 							<Popover
+								animated={false}
 								open={this.props.searchState.open}
 								anchorEl={this.props.searchState.anchorEl}
 								anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -279,6 +279,7 @@ class StaticAppBar extends Component {
                     </IconMenu>
                     <Popover
                         {...props}
+                        animated={false}
                         style={{ float: 'left', position: 'relative', marginTop: '46px', marginLeft: leftGap }}
                         open={this.state.showOptions}
                         anchorEl={this.state.anchorEl}


### PR DESCRIPTION
Fixes #1241 

Changes: Speeds up the drop-down menu animation. 
The official documentation of the Popover component didn't have any Props to customise the duration of the animation in terms of milliseconds. It had Prop only to either turn the animation on or off completely.

Demo Link: https://pr-1241-fossasia-susi-web-chat.surge.sh

