### PR TITLE
Update cookie key to render emailId on the AppBar

### DIFF
--- a/src/components/ChatApp/TopBar.react.js
+++ b/src/components/ChatApp/TopBar.react.js
@@ -215,7 +215,7 @@ class TopBar extends Component {
 								(
 									<label
 										style={{color: 'white', marginRight: '5px', fontSize: '16px', verticalAlign:'center'}}>
-										{cookies.get('emailId')}
+										{cookies.get('email')}
 									</label>):
 								(<label>
 									</label>)


### PR DESCRIPTION
Fixes #1253 

Changes: Use correct cookie name to render user EmailID on the AppBar.

Demo Link: https://pr-1254-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/21009455/40583566-01999cfa-61af-11e8-8773-124145d9e523.png)
