### PR TITLE
Corrects alignment of left navigation bar of Settings

### DIFF
--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -26,6 +26,7 @@
 }
 
 .settings-list{
+    margin-bottom: 145px;
     padding: 0px 0px;
     user-select: none;
     width: 100%;

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -1400,7 +1400,7 @@ class Settings extends Component {
 
 	let menuStyle = cookies.get('loggedIn') ?
 		{
-			 height: 600,
+			 height: 500,
 			 marginTop: 20,
 			 textAlign: 'center',
 			 display: 'inline-block',
@@ -1411,7 +1411,7 @@ class Settings extends Component {
 		:
 
 		{
-			height: 455,
+			height: 500,
 			marginTop: 20,
 			textAlign: 'center',
 			display: 'inline-block',
@@ -1440,11 +1440,11 @@ class Settings extends Component {
 	// to check if something has been modified or not
 	let somethingToSave=this.getSomethingToSave();
 		return (
-			<div className="settings-container" id="settings-container">
+			<div className="settings-container" id="settings-container" style={{overflow:'hidden'}}>
 		<StaticAppBar settings={this.state.intialSettings} {...this.props}
 			location={this.props.location} />
 				<div className='settingMenu'>
-					<Paper className='leftMenu tabStyle' zDepth={1} style={{backgroundColor:themeBackgroundColor, color:themeForegroundColor}}>
+					<Paper className='leftMenu tabStyle' zDepth={1} style={{backgroundColor:themeBackgroundColor, color:themeForegroundColor, height:'500px'}}>
 						{menuItems}
 					</Paper>
 					<Paper className='rightMenu' style={menuStyle} zDepth={1}>


### PR DESCRIPTION
Fixes #1222 

**Changes:** Corrects the alignment of left navigation bar of Settings.

**Demo Link:** https://pr-1265-fossasia-susi-web-chat.surge.sh

**Screenshots for the change:** 

Settings page when we are logged in -  
![loginsettings](https://user-images.githubusercontent.com/31135861/40628309-d9a211e4-62e1-11e8-882e-e55546767960.png)


Settings page when we are not logged in -
![logoutsettings](https://user-images.githubusercontent.com/31135861/40628313-de518f6c-62e1-11e8-91f4-3a113755db1d.png)

