### PR TITLE
Fix bug on login page when password field is empty

### DIFF
--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -205,7 +205,7 @@ class Login extends Component {
         	this.passwordErrorMessage='';
         }
 
-	    if (!state.emailError && !state.passwordError && !state.serverFieldError)
+	    if (!state.emailError && !state.passwordError && !state.serverFieldError && this.state.password !== '' && this.state.email !== '')
 	    {
 	    	state.validForm = true;
 	    }


### PR DESCRIPTION
Fixes #1280 

Changes: Fixed bug on login page. Earlier login button is enable even if password field is empty. Now we need to enter both email and password to enable it.

Demo Link: https://pr-1281-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

Earlier
![example](https://user-images.githubusercontent.com/30981465/40769580-fb74a1a6-64d5-11e8-8011-d6b9c82af91f.png)

Now
![example1](https://user-images.githubusercontent.com/30981465/40769618-185f7a5c-64d6-11e8-93be-1eb1467684b6.png)
