### PR TITLE
Consistent styling on Login and SignUp forms

### DIFF
--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -13,8 +13,6 @@ import UserPreferencesStore from '../../../stores/UserPreferencesStore';
 import CustomServer from '../../ChatApp/CustomServer.react';
 import Translate from '../../Translate/Translate.react';
 import Dialog from 'material-ui/Dialog';
-import CommunicationEmail from 'material-ui/svg-icons/communication/email';
-import ActionLock from 'material-ui/svg-icons/action/lock';
 const cookies = new Cookies();
 
 class Login extends Component {
@@ -260,7 +258,6 @@ class Login extends Component {
 					<h3><Translate text="Login to SUSI"/></h3>
 					<form onSubmit={this.handleSubmit}>
 						<div>
-						<CommunicationEmail/>
 							<TextField name="email"
                 type="email"
 								value={this.state.email}
@@ -271,7 +268,6 @@ class Login extends Component {
 								floatingLabelText={<Translate text="Email"/>} />
 						</div>
 						<div>
-						<ActionLock />
 					        <PasswordField
 						        name='password'
 								style={fieldStyle}

--- a/src/components/Auth/SignUp/SignUp.css
+++ b/src/components/Auth/SignUp/SignUp.css
@@ -13,9 +13,8 @@
 	width: 256px;
 }
 .signUpForm h3{
-	font-family: 'Open Sans', sans-serif;
 	margin: 5px 0;
-	font-weight: 500;
+	font-weight: bold;
 }
 @media screen and (max-width: 768px) {
 	.signUpForm h3{

--- a/src/components/Auth/SignUp/SignUp.react.js
+++ b/src/components/Auth/SignUp/SignUp.react.js
@@ -411,7 +411,7 @@ export default class SignUp extends Component {
                         <div>
                             <h4 style={{
                             margin: '5px 0'
-                        }}><Translate text="If you have an Account Please Login"/></h4>
+                        }}><Translate text="If you have an account please login"/></h4>
                             <RaisedButton
                                 onTouchTap={this.handleOpen}
                                 label={<Translate text='Login'/>}


### PR DESCRIPTION
Fixes #1290 

**Changes:** Made the styling of the Login and Signup forms on https://chat.susi.ai consistent with each other, and also consistent with that on https://skills.susi.ai. This involved changing font styling of the text on Signup form, and removal of the icons next to the TextFields on Login form.

**Demo Link:** https://pr-1291-fossasia-susi-web-chat.surge.sh

**Screenshots for the change:**

**Current Login Form:** 
![currentloginform](https://user-images.githubusercontent.com/31135861/40837286-a7eb6776-65b7-11e8-8f41-6c10446d840c.png)

**New Login Form:** 
![newloginform](https://user-images.githubusercontent.com/31135861/40837305-b531530a-65b7-11e8-930d-667514822363.png)

**Current Signup Form:**
![currentsignupform](https://user-images.githubusercontent.com/31135861/40837287-a836cb3a-65b7-11e8-92b0-e9896a4e62bd.png)

**New Signup Form:**
![newsignupform](https://user-images.githubusercontent.com/31135861/40837303-b4cb54ce-65b7-11e8-9906-002ae3b86fbc.png)
