### PR TITLE
Used React Routing instead of anchor tag for SUSI logo

### DIFF
--- a/src/components/ChatApp/TopBar.react.js
+++ b/src/components/ChatApp/TopBar.react.js
@@ -185,9 +185,9 @@ class TopBar extends Component {
 				}}>
 				<ToolbarGroup>
 				<div style={{ float: 'left', marginTop: '0px' }}>
-						<a href="https://chat.susi.ai/">
-						<img src={susiWhite} alt="susi-logo" style={logoStyle} />
-						</a>
+					<Link to="/">
+							<img src={susiWhite} alt="susi-logo" style={logoStyle} />
+					</Link>
 				</div>
 				</ToolbarGroup>
 				<ToolbarGroup lastChild={true}>


### PR DESCRIPTION
Fixes #1292 

Changes: SUSI Logo now routes to "/" instead of redirecting to https://chat.susi.ai when clicked.

Demo Link: https://pr-1293-fossasia-susi-web-chat.surge.sh