### PR TITLE
Fixes #1296: Resolve bug of settings menu item appearing on other routes

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -200,15 +200,16 @@ class StaticAppBar extends Component {
                 />
                 {
                     cookies.get('loggedIn')?
-                        (<MenuItem primaryText={<Translate text="Botbuilder"/>}
+                        (<div><MenuItem primaryText={<Translate text="Botbuilder"/>}
                             rightIcon={<Extension/>}
                             href="https://skills.susi.ai/botbuilder"
-                        />): null
+                        />
+                        <MenuItem primaryText={<Translate text="Settings"/>}
+                            containerElement={<Link to="/settings" />}
+                            rightIcon={<Settings />}
+                        />
+                        </div>): null
                 }
-                <MenuItem primaryText={<Translate text="Settings"/>}
-                    containerElement={<Link to="/settings" />}
-                    rightIcon={<Settings />}
-                />
                 {
                     cookies.get('loggedIn')?
                     (<MenuItem primaryText={<Translate text="Logout"/>}
@@ -357,10 +358,10 @@ class StaticAppBar extends Component {
         let menuLlinks = topLinks.map((link, i) => {
             return (
                 <MenuItem key={i}
-                          primaryText={link.label}
-                          className="drawerItem"
-                          containerElement={<Link to={link.url} />}
-                          onTouchTap={this.handleDrawerClose} >
+                    primaryText={link.label}
+                    className="drawerItem"
+                    containerElement={<Link to={link.url} />}
+                    onTouchTap={this.handleDrawerClose} >
                 </MenuItem>
             )
         });
@@ -379,7 +380,6 @@ class StaticAppBar extends Component {
                     <AppBar
                         id="headerSection"
                         className="topAppBar"
-
                         title={<div id="rightIconButton"><Link to='/' style={{ float: 'left', marginTop: '-10px',height:'25px',width:'122px' }}>
                             <img src={susiWhite} alt="susi-logo" className="siteTitle" /></Link><TopMenu /></div>}
                         style={{


### PR DESCRIPTION
Fixes #1296 

Changes: Do not display settings menu item on other pages.
Demo Link: http://susi-chat-pr-1297.surge.sh/
Screenshots for the change: 
![image](https://user-images.githubusercontent.com/21009455/40871369-e2853894-6657-11e8-962a-2d841fc5bc62.png)
