### PR TITLE
Hide email on top bar on mobile view to avoid overlapping with susi logo

### DIFF
--- a/src/components/ChatApp/TopBar.css
+++ b/src/components/ChatApp/TopBar.css
@@ -1,0 +1,5 @@
+@media only screen and (max-width: 516px){
+	.useremail{
+		display:none;
+	}
+}

--- a/src/components/ChatApp/TopBar.react.js
+++ b/src/components/ChatApp/TopBar.react.js
@@ -19,6 +19,7 @@ import Dashboard from 'material-ui/svg-icons/action/dashboard';
 import Chat from 'material-ui/svg-icons/communication/chat';
 import Extension from 'material-ui/svg-icons/action/extension';
 import Translate from '../Translate/Translate.react';
+import './TopBar.css'
 
 const cookies = new Cookies();
 let Logged = (props) => (
@@ -204,7 +205,7 @@ class TopBar extends Component {
 						{
 							cookies.get('loggedIn') ?
 								(
-									<label
+									<label className="useremail"
 										style={{color: 'white', marginRight: '5px', fontSize: '16px', verticalAlign:'center'}}>
 										{cookies.get('email')}
 									</label>):


### PR DESCRIPTION
Fixes #1302

Changes: Hide display of email on mobile view as currently susi logo shrinks and disappear while decreasing the size or on mobile view.

Demo Link: https://pr-1304-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![b1](https://user-images.githubusercontent.com/30981465/41055069-e3667c30-69dd-11e8-9414-da0cee9dcd74.png)