### PR TITLE
Fixed issues in the speech recognition toast message when mic access is yet to be allowed

### DIFF
--- a/src/components/ChatApp/MessageComposer.react.js
+++ b/src/components/ChatApp/MessageComposer.react.js
@@ -58,6 +58,7 @@ class MessageComposer extends Component {
       animate: false,
       rows: 1,
       recognizing: false,
+      micAccess: false,
       currentArrowIndex:0// store the index for moving through messages using key
     };
     this.rowComplete = 0;
@@ -73,13 +74,15 @@ class MessageComposer extends Component {
       start: true,
       stop: false,
       open: true,
+      micAccess: true,
       animate: true
     })
   }
 
   onSpeechStart = () => {
     this.setState({
-      recognizing: true
+      recognizing: true,
+      micAccess: true
     });
     flag=1;
   }
@@ -111,9 +114,11 @@ class MessageComposer extends Component {
       stop: false
     });
     if(this.state.result === ''){
-    var x = document.getElementById('snackbar')
-    x.className = 'show';
-    setTimeout(function(){ x.className = x.className.replace('show', ''); }, 3000);
+      var x = document.getElementById('snackbar')
+      if(this.state.micAccess){
+        x.className = 'show';
+        setTimeout(function(){ x.className = x.className.replace('show', ''); }, 3000);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #1163 

Changes: Fixed minor issue in the speech recognition toast message which was causing the toast message to show even when speech recogniser didn't start yet. 
To test the changes, open https://chat.susi.ai in an incognito tab, and then click on the mic icon. You'll see a popup asking for mic access. If you don't do anything, you'll see the toast message which shouldn't be the case. This is what is being fixed in this PR. Test the same thing on the demo link to test the changes.

Demo Link: https://pr-1307-fossasia-susi-web-chat.surge.sh