### PR TITLE
Send country name and code in chat.json query

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -32,6 +32,8 @@ export function getLocation(){
       _Location = {
         lat: response.latitude,
         lng: response.longitude,
+        country_code: response.country_code,
+        country_name: response.country_name
       };
     },
     error: function(xhr, status, error) {
@@ -110,7 +112,7 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
   }
   // Send location info of client if available
   if(_Location){
-    url += '&latitude='+_Location.lat+'&longitude='+_Location.lng;
+    url += '&latitude='+_Location.lat+'&longitude='+_Location.lng+'&country_code='+_Location.country_code+'&country_name='+_Location.country_name;
   }
   // Ajax Success calls the Dispatcher to CREATE_SUSI_MESSAGE only when the User is online
   if(!offlineMessage){
@@ -132,24 +134,24 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
       // Trying for empty response i.e no answer returned
       try{
       receivedMessage.text = response.answers[0].actions[0].expression;
-      	}
+        }
       catch (err) {
-      	if (err instanceof TypeError) {
-      		let emptyData = [];
-      		emptyData[0] = [];
-      		emptyData[1] = {};
-      		response.answers = [];
-      		response.answers[0] = {
-      			actions: [],
-      			data:emptyData,
-      		};
-      		response.answers[0].actions[0] = {
-      			expression:defaultMessage,
-      			language:'en',
-      			type:'answer',
-      		   		   	};
-        	receivedMessage.text = response.answers[0].actions[0].expression;
-    	}
+        if (err instanceof TypeError) {
+          let emptyData = [];
+          emptyData[0] = [];
+          emptyData[1] = {};
+          response.answers = [];
+          response.answers[0] = {
+            actions: [],
+            data:emptyData,
+          };
+          response.answers[0].actions[0] = {
+            expression:defaultMessage,
+            language:'en',
+            type:'answer',
+                    };
+          receivedMessage.text = response.answers[0].actions[0].expression;
+      }
       }
       if(receivedMessage.lang===undefined){
         receivedMessage.lang = document.documentElement.getAttribute('lang');

--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -32,8 +32,8 @@ export function getLocation(){
       _Location = {
         lat: response.latitude,
         lng: response.longitude,
-        country_code: response.country_code,
-        country_name: response.country_name
+        countryCode: response.country_code,
+        countryName: response.country_name
       };
     },
     error: function(xhr, status, error) {
@@ -112,7 +112,7 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
   }
   // Send location info of client if available
   if(_Location){
-    url += '&latitude='+_Location.lat+'&longitude='+_Location.lng+'&country_code='+_Location.country_code+'&country_name='+_Location.country_name;
+    url += '&latitude='+_Location.lat+'&longitude='+_Location.lng+'&country_code='+_Location.countryCode+'&country_name='+_Location.countryName;
   }
   // Ajax Success calls the Dispatcher to CREATE_SUSI_MESSAGE only when the User is online
   if(!offlineMessage){


### PR DESCRIPTION
Fixes 
Send country name and country code in chat.json API #1308

Changes: 
1. Fetched country name and country code along with latitude and longitude from the following API
`https://cors-anywhere.herokuapp.com/http://freegeoip.net/json/`

2. Append country_name and country_code in the chat.json API call.


Demo Link: https://susi--cms.surge.sh

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/10573038/41161302-02316f26-6b50-11e8-8fe0-3af9e5a565d7.png)

![image](https://user-images.githubusercontent.com/10573038/41161325-1572131a-6b50-11e8-9ced-5001c9ad06a8.png)


