### PR TITLE
Enable ticks while sending message on SUSI 

### DIFF
--- a/src/components/ChatApp/MessageListItem/helperFunctions.react.js
+++ b/src/components/ChatApp/MessageListItem/helperFunctions.react.js
@@ -45,6 +45,11 @@ export function renderAnchor(text,link){
 export function renderMessageFooter(message,latestMsgID, isLastAction){
 
   let statusIndicator = null;
+  let ticks = (
+    <span>
+     &#9989;
+   </span>
+ );
 
   let footerStyle = {
     display: 'block',
@@ -76,13 +81,16 @@ export function renderMessageFooter(message,latestMsgID, isLastAction){
           color={UserPreferencesStore.getTheme()==='light' ? '#90a4ae' : '#7eaaaf'}
           onClick={()=> window.open(twitterShare, '_blank')}
           />
+          {ticks}
       </li>);
     if(message.id === latestMsgID){
       statusIndicator = (
         <li className='response-time' style={footerStyle}>
           <ClockIcon style={indicatorStyle}
             color={UserPreferencesStore.getTheme()==='light' ? '#90a4ae' : '#7eaaaf'}/>
-        </li>);
+        </li>
+
+    );
     }
   }
 


### PR DESCRIPTION
Fixes #1310 

Changes: [Add here what changes were made in this issue and if possible provide links.]

Enables ticks (as seen messages) when sender sends a message (like WhatsApp , or Messenger)

Demo Link: http://private-wood.surge.sh/

Screenshots for the change: 

![screenshot 124](https://user-images.githubusercontent.com/16035442/41198371-b55313e2-6c96-11e8-89cd-bfec090aa334.png)
