### PR TITLE
Send device type in chat.json query

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -114,6 +114,10 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
   if(_Location){
     url += '&latitude='+_Location.lat+'&longitude='+_Location.lng+'&country_code='+_Location.countryCode+'&country_name='+_Location.countryName;
   }
+  // Add the type of device in the query
+  {
+    url += "&device_type=Web Client";
+  }
   // Ajax Success calls the Dispatcher to CREATE_SUSI_MESSAGE only when the User is online
   if(!offlineMessage){
   $.ajax({

--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -116,7 +116,7 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
   }
   // Add the type of device in the query
   {
-    url += "&device_type=Web Client";
+    url += '&device_type=Web Client';
   }
   // Ajax Success calls the Dispatcher to CREATE_SUSI_MESSAGE only when the User is online
   if(!offlineMessage){


### PR DESCRIPTION
Fixes 
Send device type in chat.json API #1328 

Changes: 
1. Append device_type="Web Client" in the chat.json API call.

Demo Link: https://susi-ai-chat.surge.sh

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/10573038/41338836-ed684406-6f10-11e8-8d12-f22c336f3c1c.png)

