### PR TITLE
Send feedback logs for analysis

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -136,9 +136,8 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
       _Location.countryName;
   }
   // Add the type of device in the query
-  {
-    url += '&device_type=Web Client';
-  }
+  url += '&device_type=Web Client';
+
   // Ajax Success calls the Dispatcher to CREATE_SUSI_MESSAGE only when the User is online
   if (!offlineMessage) {
     $.ajax({


### PR DESCRIPTION
Fixes 
Send feedback data for creating logs on server #1347
Strictly merge the server side PR before this one : https://github.com/fossasia/susi_server/pull/835

Changes: 
Created sendFeedbackLogs() function to send the feedback related data for creating logs on the server. The requests sends the following data:
- model
- group
- language
- skill
- feedback
- user_query
- susi_reply
- country_name
- country_code

Demo Link: https://susi-ai-chat.surge.sh

Screenshots for the change: 
NA