### PR TITLE
Rearrange hamburger menu

### DIFF
--- a/src/components/ChatApp/TopBar.react.js
+++ b/src/components/ChatApp/TopBar.react.js
@@ -18,6 +18,7 @@ import Info from 'material-ui/svg-icons/action/info';
 import Dashboard from 'material-ui/svg-icons/action/dashboard';
 import Chat from 'material-ui/svg-icons/communication/chat';
 import Extension from 'material-ui/svg-icons/action/extension';
+import Assessment from 'material-ui/svg-icons/action/assessment';
 import Translate from '../Translate/Translate.react';
 import './TopBar.css'
 
@@ -84,9 +85,9 @@ class TopBar extends Component {
 					targetOrigin={{ horizontal: 'right', vertical: 'top' }}
 					onRequestClose={this.closeOptions}
 				>
-					<MenuItem primaryText={<Translate text="About"/>}
-						containerElement={<Link to="/overview" />}
-						rightIcon={<Info/>}
+					<MenuItem primaryText={<Translate text="Dashboard"/>}
+						rightIcon={<Assessment />}
+						href="https://skills.susi.ai/dashboard"
 					/>
 					<MenuItem primaryText={<Translate text="Chat"/>}
 						containerElement={<Link to="/" />}
@@ -102,13 +103,17 @@ class TopBar extends Component {
 						onClick={this.props.handleThemeChanger}
 						rightIcon={<Edit/>}
 					/>
-					<MenuItem primaryText={<Translate text="Dashboard"/>}
-						rightIcon={<Extension/>}
-						href="https://skills.susi.ai/dashboard"
+					<MenuItem primaryText={<Translate text="Botbuilder"/>}
+						rightIcon={<Extension />}
+						href="https://skills.susi.ai/botbuilder"
 					/>
 					<MenuItem primaryText={<Translate text="Settings"/>}
 						containerElement={<Link to="/settings" />}
 						rightIcon={<Settings/>}/>
+					<MenuItem primaryText={<Translate text="About"/>}
+						containerElement={<Link to="/overview" />}
+						rightIcon={<Info/>}
+					/>
 					<MenuItem primaryText={<Translate text="Logout"/>}
 						containerElement={<Link to="/logout" />}
 						rightIcon={<Exit />}/>
@@ -136,10 +141,6 @@ class TopBar extends Component {
 					targetOrigin={{ horizontal: 'right', vertical: 'top' }}
 					onRequestClose={this.closeOptions}
 				>
-					<MenuItem primaryText={<Translate text="About"/>}
-						containerElement={<Link to="/overview" />}
-						rightIcon={<Info/>}
-					/>
 					<MenuItem primaryText={<Translate text="Chat"/>}
 						containerElement={<Link to="/" />}
 						rightIcon={<Chat/>}
@@ -149,6 +150,10 @@ class TopBar extends Component {
 						href="https://skills.susi.ai"
 					><Translate text="Skills"/>
 					</MenuItem>
+					<MenuItem primaryText={<Translate text="About"/>}
+						containerElement={<Link to="/overview" />}
+						rightIcon={<Info/>}
+					/>
 					<MenuItem primaryText={<Translate text="Login"/>}
 						onTouchTap={this.props.handleOpen}
 					rightIcon={<SignUp/>} />

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -31,10 +31,6 @@ const cookies = new Cookies();
 
 let Logged = (props) => (
     <div>
-        <MenuItem primaryText="About"
-            containerElement={<Link to="/overview" />}
-            rightIcon={<Info />}
-        />
         <MenuItem primaryText="Chat"
             containerElement={<Link to="/" />}
             rightIcon={<Chat />}
@@ -49,6 +45,10 @@ let Logged = (props) => (
             }}
             href="https://skills.susi.ai">Skills</a>
         </MenuItem>
+        <MenuItem primaryText="About"
+            containerElement={<Link to="/overview" />}
+            rightIcon={<Info />}
+        />
         <MenuItem
             primaryText="Login"
             onTouchTap={this.handleLogin}
@@ -186,10 +186,6 @@ class StaticAppBar extends Component {
         // Return menu items for the hamburger menu
         Logged = (props) => (
             <div>
-                <MenuItem primaryText={<Translate text="About"/>}
-                    containerElement={<Link to="/overview" />}
-                    rightIcon={<Info />}
-                />
                 <MenuItem primaryText={<Translate text="Chat"/>}
                     containerElement={<Link to="/" />}
                     rightIcon={<Chat />}
@@ -210,6 +206,10 @@ class StaticAppBar extends Component {
                         />
                         </div>): null
                 }
+                <MenuItem primaryText={<Translate text="About"/>}
+                    containerElement={<Link to="/overview" />}
+                    rightIcon={<Info />}
+                />
                 {
                     cookies.get('loggedIn')?
                     (<MenuItem primaryText={<Translate text="Logout"/>}


### PR DESCRIPTION
Fixes #1346 

Changes:
- Added "Dashboard" to the top.
- "About" is on the bottom just above login/logout.
- "Botbuilder" is at the current place of "Dashboard".

Demo Link: https://pr-1349-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

Not logged in:
<img width="137" alt="screen shot 2018-06-16 at 8 31 54 pm" src="https://user-images.githubusercontent.com/31174685/41499834-fc702310-71a4-11e8-9561-ba835cd6f3ae.png">

Logged in:
<img width="169" alt="screen shot 2018-06-16 at 8 31 40 pm" src="https://user-images.githubusercontent.com/31174685/41499835-014e1aae-71a5-11e8-9521-fdbca37094a6.png">
