### PR TITLE
Display name of the user instead of email on top bar

### DIFF
--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -218,6 +218,7 @@ class Login extends Component {
 		if (state.success) {
 			cookies.set('loggedIn', loggedIn, { path: '/', maxAge: time });
 			cookies.set('email', email, { path: '/', maxAge: time });
+			cookies.set('username', UserPreferencesStore.getUserName(), { path: '/', maxAge: time });
 			this.props.history.push('/', { showLogin: false });
 			window.location.reload();
 		}

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -374,6 +374,7 @@ class Settings extends Component {
 		this.setInitialSettings();
 		// Trigger Actions to save the settings in stores and server
 		this.implementSettings(vals);
+		cookies.set('username',vals.userName);
 	}
 
 	// Store the settings in stores and server

--- a/src/components/ChatApp/TopBar.react.js
+++ b/src/components/ChatApp/TopBar.react.js
@@ -20,6 +20,7 @@ import Chat from 'material-ui/svg-icons/communication/chat';
 import Extension from 'material-ui/svg-icons/action/extension';
 import Assessment from 'material-ui/svg-icons/action/assessment';
 import Translate from '../Translate/Translate.react';
+import UserPreferencesStore from '../../stores/UserPreferencesStore';
 import './TopBar.css'
 
 const cookies = new Cookies();
@@ -210,7 +211,7 @@ class TopBar extends Component {
 								(
 									<label className="useremail"
 										style={{color: 'white', marginRight: '5px', fontSize: '16px', verticalAlign:'center'}}>
-										{cookies.get('email')}
+										{UserPreferencesStore.getUserName()}
 									</label>):
 								(<label>
 									</label>)

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -24,6 +24,7 @@ import Settings from 'material-ui/svg-icons/action/settings';
 import susiWhite from '../../images/susi-logo-white.png';
 import Translate from '../Translate/Translate.react';
 import Extension from 'material-ui/svg-icons/action/extension';
+import UserPreferencesStore from '../../stores/UserPreferencesStore';
 
 import { Link } from 'react-router-dom';
 
@@ -252,7 +253,7 @@ class StaticAppBar extends Component {
                             (
                                 <label
                                     style={{color: 'white', marginRight: '5px', fontSize: '16px', verticalAlign:'center'}}>
-                                    {cookies.get('email')}
+                                    {UserPreferencesStore.getUserName()}
                                 </label>):
                             (<label>
                                 </label>)


### PR DESCRIPTION
Fixes #1337

Changes: Now the name of the user is displayed on the top bar instead of the email.

Demo Link: https://pr-1350-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

![usernametopbar](https://user-images.githubusercontent.com/31135861/41507352-b5a3692e-724e-11e8-9c11-e5a1be6cb65e.gif)
