### PR TITLE
Display email of the user on the top bar if name hasn't been saved yet

### DIFF
--- a/src/components/ChatApp/TopBar.react.js
+++ b/src/components/ChatApp/TopBar.react.js
@@ -226,7 +226,10 @@ class TopBar extends Component {
                   verticalAlign: 'center',
                 }}
               >
-                {UserPreferencesStore.getUserName()}
+                {UserPreferencesStore.getUserName() === '' ||
+                UserPreferencesStore.getUserName() === 'undefined'
+                  ? cookies.get('email')
+                  : UserPreferencesStore.getUserName()}
               </label>
             ) : (
               <label />

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -275,7 +275,10 @@ class StaticAppBar extends Component {
                   verticalAlign: 'center',
                 }}
               >
-                {UserPreferencesStore.getUserName()}
+                {UserPreferencesStore.getUserName() === '' ||
+                UserPreferencesStore.getUserName() === 'undefined'
+                  ? cookies.get('email')
+                  : UserPreferencesStore.getUserName()}
               </label>
             ) : (
               <label />


### PR DESCRIPTION
Fixes #1360 

Changes: Now the email of the user would be displayed on the top bar if he hasn't saved his name yet.

Demo Link: https://pr-1362-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![screenshot from 2018-06-20 15-01-36](https://user-images.githubusercontent.com/31135861/41650099-d86be23a-749a-11e8-8819-95b596369d10.png)

