### PR TITLE
Added "Geolocation" and "Room" columns in the Devices table + Minor improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "predeploy": "npm run build",
     "deploy": "surge"
   },
-   "lint-staged": {
+  "lint-staged": {
     "src/**/*.js": [
       "eslint src --ext .js",
       "prettier --write",

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -1292,14 +1292,13 @@ class Settings extends Component {
       );
     } else if (this.state.selectedSetting === 'Devices') {
       currentSetting = (
-        <span style={divStyle}>
-          <div>
+        <span style={{ right: '40px' }}>
+          <div style={divStyle}>
             <span>
               <div
                 style={{
                   marginTop: '10px',
-                  marginBottom: '5px',
-                  marginLeft: '30px',
+                  marginBottom: '10px',
                   fontSize: '16px',
                   fontWeight: 'bold',
                 }}
@@ -1308,14 +1307,23 @@ class Settings extends Component {
               </div>
             </span>
             {UserPreferencesStore.getTheme() === 'light' ? (
-              <hr className="break-line-light" style={{ height: '2px' }} />
+              <hr
+                className="break-line-light"
+                style={{ height: '2px', marginBottom: '10px' }}
+              />
             ) : (
-              <hr className="break-line-dark" />
+              <hr
+                className="break-line-dark"
+                style={{ height: '2px', marginBottom: '10px' }}
+              />
             )}
             <div>
               <div style={{ overflowX: 'hidden' }}>
                 {this.state.deviceData ? (
-                  <div className="table">
+                  <div
+                    className="table"
+                    style={{ left: '0px', marginTop: '0px', width: '550px' }}
+                  >
                     <TableComplex tableData={obj} />
                   </div>
                 ) : (

--- a/src/components/TableComplex/TableComplex.react.js
+++ b/src/components/TableComplex/TableComplex.react.js
@@ -39,14 +39,41 @@ export default class TableComplex extends Component {
             enableSelectAll={this.state.enableSelectAll}
           >
             <TableRow>
-              <TableHeaderColumn style={{ width: '50px' }}>
-                S. No.
+              <TableHeaderColumn
+                style={{
+                  width: '120px',
+                  whiteSpace: 'normal',
+                  wordWrap: 'break-word',
+                }}
+              >
+                Device Name
               </TableHeaderColumn>
-              <TableHeaderColumn style={{ width: '120px' }}>
+              <TableHeaderColumn
+                style={{
+                  width: '120px',
+                  whiteSpace: 'normal',
+                  wordWrap: 'break-word',
+                }}
+              >
                 Mac Address
               </TableHeaderColumn>
-              <TableHeaderColumn style={{ width: '120px' }}>
-                Name of Device
+              <TableHeaderColumn
+                style={{
+                  width: '120px',
+                  whiteSpace: 'normal',
+                  wordWrap: 'break-word',
+                }}
+              >
+                Room
+              </TableHeaderColumn>
+              <TableHeaderColumn
+                style={{
+                  width: '120px',
+                  whiteSpace: 'normal',
+                  wordWrap: 'break-word',
+                }}
+              >
+                Geolocation
               </TableHeaderColumn>
             </TableRow>
           </TableHeader>
@@ -59,14 +86,41 @@ export default class TableComplex extends Component {
             {/* eslint-disable-next-line */}
             {this.props.tableData.map((row, index) => (
               <TableRow key={index}>
-                <TableRowColumn style={{ width: '50px' }}>
-                  {index + 1}
+                <TableRowColumn
+                  style={{
+                    width: '120px',
+                    whiteSpace: 'normal',
+                    wordWrap: 'break-word',
+                  }}
+                >
+                  {row.devicename}
                 </TableRowColumn>
-                <TableRowColumn style={{ width: '120px' }}>
+                <TableRowColumn
+                  style={{
+                    width: '120px',
+                    whiteSpace: 'normal',
+                    wordWrap: 'break-word',
+                  }}
+                >
                   {row.macid}
                 </TableRowColumn>
-                <TableRowColumn style={{ width: '120px' }}>
+                <TableRowColumn
+                  style={{
+                    width: '120px',
+                    whiteSpace: 'normal',
+                    wordWrap: 'break-word',
+                  }}
+                >
                   {row.devicename}
+                </TableRowColumn>
+                <TableRowColumn
+                  style={{
+                    width: '120px',
+                    whiteSpace: 'normal',
+                    wordWrap: 'break-word',
+                  }}
+                >
+                  {row.macid}
                 </TableRowColumn>
               </TableRow>
             ))}


### PR DESCRIPTION
Partially fixes #1361 
- [x] Remove the 1st column of the table and make Device name as the 1st column
- [x] Improve alignment of the table in the Devices tab to match the styling of other tabs
- [x] Implement "geolocation" and "room" columns in the table in the Devices tab

**Changes:** Added "Geolocation" and "Room" columns in the Devices table and other minor improvements as mentioned above.

**Note:** Currently, I'm using data for the first two columns in the newly added columns. I'll modify the `/aaa/addNewDevice.json` endpoint on the server to accept 2 more parameters - `room` and `geolocation`. After that is done, then the data for the newly added columns could be added using that.

**Demo Link:** https://pr-1364-fossasia-susi-web-chat.surge.sh

**Screenshots for the change:** 
![addcolumnsdevicetab](https://user-images.githubusercontent.com/31135861/41669741-1fe1fcd2-74d0-11e8-8a36-837ffb85d125.png)


