### PR TITLE
Rearrange hamburger menu for all routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "predeploy": "npm run build",
     "deploy": "surge"
   },
-   "lint-staged": {
+  "lint-staged": {
     "src/**/*.js": [
       "eslint src --ext .js",
       "prettier --write",

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -24,6 +24,7 @@ import Settings from 'material-ui/svg-icons/action/settings';
 import susiWhite from '../../images/susi-logo-white.png';
 import Translate from '../Translate/Translate.react';
 import Extension from 'material-ui/svg-icons/action/extension';
+import Assessment from 'material-ui/svg-icons/action/assessment';
 import UserPreferencesStore from '../../stores/UserPreferencesStore';
 
 import { Link } from 'react-router-dom';
@@ -196,6 +197,13 @@ class StaticAppBar extends Component {
     // Return menu items for the hamburger menu
     Logged = props => (
       <div>
+        {cookies.get('loggedIn') ? (
+          <MenuItem
+            primaryText={<Translate text="Dashboard" />}
+            rightIcon={<Assessment />}
+            href="https://skills.susi.ai/dashboard"
+          />
+        ) : null}
         <MenuItem
           primaryText={<Translate text="Chat" />}
           containerElement={<Link to="/" />}
@@ -209,9 +217,9 @@ class StaticAppBar extends Component {
         {cookies.get('loggedIn') ? (
           <div>
             <MenuItem
-              primaryText={<Translate text="Dashboard" />}
+              primaryText={<Translate text="Botbuilder" />}
               rightIcon={<Extension />}
-              href="https://skills.susi.ai/dashboard"
+              href="https://skills.susi.ai/botbuilder"
             />
             <MenuItem
               primaryText={<Translate text="Settings" />}


### PR DESCRIPTION
Fixes #1346 

Changes: Rearranged hamburger menu for all routes

Demo Link: https://pr-1365-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

Not logged in:
<img width="137" alt="screen shot 2018-06-16 at 8 31 54 pm" src="https://user-images.githubusercontent.com/31174685/41499834-fc702310-71a4-11e8-9561-ba835cd6f3ae.png">

Logged in:
<img width="171" alt="screen shot 2018-06-20 at 11 38 28 pm" src="https://user-images.githubusercontent.com/31174685/41676424-1292abc2-74e3-11e8-9617-4f3f9e81881e.png">
