### PR TITLE
Put gray background by default in settings

### DIFF
--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -27,7 +27,7 @@
 .settings-container-light{
   width: 100%;
   height: 100vh;
-  background: rgb(255, 255, 255);
+  background: rgb(242, 242, 242);
 }
 
 .settings-container-dark{


### PR DESCRIPTION
Fixes #1363 

Changes: Put background of settings to be gray (`rgb(242, 242, 242)`) by default. I didn't change the background of chat page because the chat window is already gray.

Demo Link: https://pr-1372-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
<img width="1118" alt="screen shot 2018-06-22 at 7 12 15 am" src="https://user-images.githubusercontent.com/31174685/41753533-a0a54d76-75eb-11e8-9657-7f61420a8b3f.png">

