### PR TITLE
Fetched data from API instead of using data of first 2 columns in Devices table

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -102,7 +102,10 @@ class Settings extends Component {
           keys.forEach(i => {
             let myObj = {
               macid: i,
-              devicename: Object.keys(response.devices[i])[0],
+              devicename: response.devices[i].name,
+              room: response.devices[i].room,
+              latitude: response.devices[i].geolocation.latitude,
+              longitude: response.devices[i].geolocation.longitude,
             };
             obj.push(myObj);
             this.setState({

--- a/src/components/TableComplex/TableComplex.react.js
+++ b/src/components/TableComplex/TableComplex.react.js
@@ -111,7 +111,7 @@ export default class TableComplex extends Component {
                     wordWrap: 'break-word',
                   }}
                 >
-                  {row.devicename}
+                  {row.room}
                 </TableRowColumn>
                 <TableRowColumn
                   style={{
@@ -120,7 +120,7 @@ export default class TableComplex extends Component {
                     wordWrap: 'break-word',
                   }}
                 >
-                  {row.macid}
+                  {row.latitude}, {row.longitude}
                 </TableRowColumn>
               </TableRow>
             ))}


### PR DESCRIPTION
Partially fixes #1361 
- [x] Use data from API for the "geolocation" and "room" columns

Changes: Now, the "room" and "geolocation" columns of the Devices table will display data fetched from the API (as https://github.com/fossasia/susi_server/pull/873 is merged now).

Demo Link: https://pr-1377-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![screenshot from 2018-06-22 23-04-38](https://user-images.githubusercontent.com/31135861/41790609-bd50a404-7670-11e8-9bef-a4294d5206bb.png)


