### PR TITLE
reCAPTCHA in sign-up page #1344

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-linkify": "^0.2.1",
     "react-loading-animation": "^1.3.0",
     "react-modal": "^2.2.2",
+    "react-recaptcha": "^2.3.8",
     "react-render-html": "^0.5.0",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
     <meta content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
+    <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script> 
     <!--
       Notice the use of %PUBLIC_URL% in the tag above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/components/Auth/SignUp/SignUp.css
+++ b/src/components/Auth/SignUp/SignUp.css
@@ -32,3 +32,10 @@
 	color: #365899;
 	text-decoration: underline;
 }
+
+.error-message{
+    font-size: 12px;
+    line-height: 12px;
+    color: rgb(244, 67, 54);
+    margin-top: 5.7px;
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,1 @@
+export const KEY = '6LfPZGAUAAAAANY4ZLR_lSat_YCuqqcV3sl84ulW';


### PR DESCRIPTION
Fixes #1344 

Added google reCAPTCHA v2 with 2 options, audio and image.
Note: The captcha challenges wont resize if we resize the page due to material ui dialog box. Its not a problem from the captcha side. We can either make a new route for sign up page, without a dialog box after this.

**Changes:** [Add here what changes were made in this issue and if possible provide links.]

**Demo Link:** https://pr-1344-fossasia-susi-web-chat.surge.sh

**Screenshots for the change:** 

<img width="300" alt="screen shot 2018-06-24 at 1 15 18 am" src="https://user-images.githubusercontent.com/18073126/41813070-65ac25fc-774c-11e8-9f22-48fd9c34e313.png">
<img width="300" alt="screen shot 2018-06-24 at 1 14 58 am" src="https://user-images.githubusercontent.com/18073126/41813074-69fb33d2-774c-11e8-9c13-16b4958a1eaf.png">