### PR TITLE
Delete device info from server when Delete icon is clicked

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -74,8 +74,29 @@ class Settings extends Component {
 
   handleRemove = i => {
     let data = this.state.obj;
+    let macid = data[i].macid;
+
     this.setState({
       obj: data.filter((row, j) => j !== i),
+    });
+
+    $.ajax({
+      url:
+        BASE_URL +
+        '/aaa/removeUserDevices.json?macid=' +
+        macid +
+        '&access_token=' +
+        cookies.get('loggedIn'),
+      dataType: 'jsonp',
+      crossDomain: true,
+      timeout: 3000,
+      async: false,
+      success: function(response) {
+        console.log(response);
+      },
+      error: function(errorThrown) {
+        console.log(errorThrown);
+      },
     });
   };
 


### PR DESCRIPTION
Partially solves #1361
- [x] Implement remove option in devices tab.

Changes: Now, clicking on the delete icon deletes the info of the device from the server.

Demo Link: https://pr-1381-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![deletedevicesonserver](https://user-images.githubusercontent.com/31135861/41822883-4bed8386-7814-11e8-9779-4677fdcef083.gif)
