### PR TITLE
Update device info on server when Edit icon is used in the Devices table

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -83,8 +83,42 @@ class Settings extends Component {
     this.setState({ editIdx: i });
   };
 
-  stopEditing = () => {
+  stopEditing = i => {
+    let data = this.state.obj;
+    let macid = data[i].macid;
+    let devicename = data[i].devicename;
+    let room = data[i].room;
+    let latitude = data[i].latitude;
+    let longitude = data[i].longitude;
+
     this.setState({ editIdx: -1 });
+
+    $.ajax({
+      url:
+        BASE_URL +
+        '/aaa/addNewDevice.json?macid=' +
+        macid +
+        '&name=' +
+        devicename +
+        '&room=' +
+        room +
+        '&latitude=' +
+        latitude +
+        '&longitude=' +
+        longitude +
+        '&access_token=' +
+        cookies.get('loggedIn'),
+      dataType: 'jsonp',
+      crossDomain: true,
+      timeout: 3000,
+      async: false,
+      success: function(response) {
+        console.log(response);
+      },
+      error: function(errorThrown) {
+        console.log(errorThrown);
+      },
+    });
   };
 
   handleChange = (e, name, i) => {

--- a/src/components/TableComplex/TableComplex.react.js
+++ b/src/components/TableComplex/TableComplex.react.js
@@ -173,7 +173,7 @@ export default class TableComplex extends Component {
                 >
                   {this.props.editIdx === index ? (
                     <CheckIcon
-                      onClick={() => this.props.stopEditing()}
+                      onClick={() => this.props.stopEditing(index)}
                       style={{ cursor: 'pointer' }}
                     />
                   ) : (


### PR DESCRIPTION
Partially solves #1361
- [x] Implement edit device option in devices tab.

Changes: Now, editing info of the device using the Edit icon would save the updated device info on the server.

Demo Link: https://pr-1383-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![editdevicesonserver](https://user-images.githubusercontent.com/31135861/41823285-1852b26a-781b-11e8-9259-6e8c9eae6a6a.gif)
