### PR TITLE
Added a confirmation dialog for removing devices

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -14,6 +14,7 @@ import TextToSpeechSettings from './TextToSpeechSettings.react';
 import Close from 'material-ui/svg-icons/navigation/close';
 import ChangePassword from '../../Auth/ChangePassword/ChangePassword.react';
 import ForgotPassword from '../../Auth/ForgotPassword/ForgotPassword.react';
+import RemoveDeviceDialog from '../../TableComplex/RemoveDeviceDialog.react';
 import './Settings.css';
 import Translate from '../../Translate/Translate.react';
 import TextField from 'material-ui/TextField';
@@ -69,6 +70,7 @@ class Settings extends Component {
       deviceData: false,
       obj: [],
       editIdx: -1,
+      removeDevice: -1,
     };
   }
 
@@ -96,6 +98,9 @@ class Settings extends Component {
       },
       error: function(errorThrown) {
         console.log(errorThrown);
+      },
+      complete: function(jqXHR, textStatus) {
+        location.reload();
       },
     });
   };
@@ -319,6 +324,7 @@ class Settings extends Component {
       showSignUp: false,
       showForgotPassword: false,
       showOptions: false,
+      showRemoveConfirmation: false,
       anchorEl: null,
       slideIndex: 0,
       countryCode: defaultCountryCode,
@@ -415,6 +421,7 @@ class Settings extends Component {
       showLogin: false,
       showSignUp: false,
       showForgotPassword: false,
+      showRemoveConfirmation: false,
     });
   };
 
@@ -611,6 +618,7 @@ class Settings extends Component {
       showSignUp: false,
       showForgotPassword: false,
       showOptions: false,
+      showRemoveConfirmation: false,
     });
   };
 
@@ -621,6 +629,7 @@ class Settings extends Component {
       showLogin: false,
       showForgotPassword: false,
       showOptions: false,
+      showRemoveConfirmation: false,
     });
   };
 
@@ -630,6 +639,21 @@ class Settings extends Component {
       showForgotPassword: true,
       showLogin: false,
       showOptions: false,
+      showRemoveConfirmation: false,
+    });
+  };
+
+  // Open Remove Device Confirmation dialog
+  handleRemoveConfirmation = i => {
+    let data = this.state.obj;
+    let devicename = data[i].devicename;
+    this.setState({
+      showRemoveConfirmation: true,
+      showForgotPassword: false,
+      showLogin: false,
+      showOptions: false,
+      removeDevice: i,
+      removeDeviceName: devicename,
     });
   };
 
@@ -1337,6 +1361,7 @@ class Settings extends Component {
                   >
                     <TableComplex
                       handleRemove={this.handleRemove}
+                      handleRemoveConfirmation={this.handleRemoveConfirmation}
                       startEditing={this.startEditing}
                       editIdx={this.state.editIdx}
                       stopEditing={this.stopEditing}
@@ -1885,6 +1910,22 @@ class Settings extends Component {
             : 'settings-container-dark'
         }
       >
+        <Dialog
+          className="dialogStyle"
+          modal={false}
+          open={this.state.showRemoveConfirmation}
+          autoScrollBodyContent={true}
+          contentStyle={{ width: '35%', minWidth: '300px' }}
+          onRequestClose={this.handleClose}
+        >
+          <RemoveDeviceDialog
+            {...this.props}
+            deviceIndex={this.state.removeDevice}
+            devicename={this.state.removeDeviceName}
+            handleRemove={this.handleRemove}
+          />
+          <Close style={closingStyle} onTouchTap={this.handleClose} />
+        </Dialog>
         <StaticAppBar
           settings={this.state.intialSettings}
           {...this.props}

--- a/src/components/TableComplex/RemoveDeviceDialog.css
+++ b/src/components/TableComplex/RemoveDeviceDialog.css
@@ -1,0 +1,16 @@
+.removeDeviceForm{
+	margin: 0 auto;
+	padding: 0px;
+}
+
+.removeDeviceForm h3{
+	font-family: 'Open Sans', sans-serif;
+	margin: 5px 0;
+	font-weight: 500;
+}
+
+@media screen and (max-width: 768px) {
+	.removeDeviceForm h3{
+		font-size: 16px;
+	}
+}

--- a/src/components/TableComplex/RemoveDeviceDialog.react.js
+++ b/src/components/TableComplex/RemoveDeviceDialog.react.js
@@ -1,0 +1,166 @@
+import React, { Component } from 'react';
+import Paper from 'material-ui/Paper';
+import TextField from 'material-ui/TextField';
+import RaisedButton from 'material-ui/RaisedButton';
+import './RemoveDeviceDialog.css';
+import PropTypes from 'prop-types';
+import $ from 'jquery';
+import Translate from '../Translate/Translate.react';
+
+class RemoveDeviceDialog extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      devicename: '',
+      correctName: false,
+    };
+  }
+
+  componentDidMount = () => {
+    let fieldWidth = $('#returnDiv').width();
+    $('#returnDiv')
+      .parent()
+      .css({ padding: '0px', color: 'red' });
+    $('#removeDeviceButton').css({
+      width: fieldWidth + 6,
+      transition: 'none',
+    });
+    $('#devicename')
+      .parent()
+      .css({ width: fieldWidth - 16 });
+  };
+  // Handle changes in device name
+  handleChange = event => {
+    this.setState({
+      devicename: event.target.value,
+      correctName: event.target.value === this.props.devicename,
+    });
+  };
+
+  render() {
+    const styles = {
+      width: '100%',
+      textAlign: 'center',
+      padding: '0px',
+    };
+    const fieldStyle = {
+      height: '35px',
+      borderRadius: 4,
+      border: '1px solid #ced4da',
+      fontSize: 16,
+      padding: '0px 10px',
+      width: '250px',
+      marginTop: '0px',
+    };
+    const inputStyle = {
+      height: '35px',
+      marginBottom: '10px',
+    };
+
+    return (
+      <div className="removeDeviceForm" id="returnDiv">
+        <Paper zDepth={0} style={styles}>
+          <div
+            style={{
+              backgroundColor: '#f6f8fa',
+              color: '#24292e',
+              padding: '16px',
+              border: '1px solid rgba(27,31,35,0.15)',
+              fontSize: '14px',
+              textAlign: 'left',
+              fontWeight: '600',
+              lineHeight: '1.5',
+            }}
+          >
+            Are you absolutely sure?
+          </div>
+          <div
+            style={{
+              backgroundColor: '#fffbdd',
+              color: '#735c0f',
+              padding: '16px',
+              border: '1px solid rgba(27,31,35,0.15)',
+              fontSize: '14px',
+              textAlign: 'left',
+              lineHeight: '1.5',
+            }}
+          >
+            Unexpected bad things will happen if you don’t read this!
+          </div>
+          <div
+            style={{
+              backgroundColor: '#ffffff',
+              color: '#24292e',
+              padding: '16px',
+              border: '1px solid rgba(27,31,35,0.15)',
+              fontSize: '14px',
+              textAlign: 'left',
+              fontWeight: '400',
+              lineHeight: '1.5',
+            }}
+          >
+            <p style={{ marginTop: '0px', marginBottom: '10px' }}>
+              This action <strong>cannot</strong> be undone. This will
+              permanently remove the device corresponding to the device name{' '}
+              <strong>{this.props.devicename}</strong>.
+            </p>
+            <p style={{ marginTop: '0px', marginBottom: '10px' }}>
+              Please type in the name of the device to confirm.
+            </p>
+            <div style={{ textAlign: 'center' }}>
+              <TextField
+                id="devicename"
+                name="devicename"
+                value={this.state.devicename}
+                inputStyle={inputStyle}
+                style={fieldStyle}
+                placeholder=""
+                underlineStyle={{ display: 'none' }}
+                onChange={this.handleChange}
+                autoComplete="off"
+                width="100%"
+              />
+            </div>
+            {/* Remove Device Button */}
+            <div style={{ textAlign: 'center' }}>
+              <RaisedButton
+                id="removeDeviceButton"
+                onClick={() => this.props.handleRemove(this.props.deviceIndex)}
+                label={<Translate text="I understand, remove device" />}
+                backgroundColor="#cb2431"
+                style={{
+                  boxShadow: 'none',
+                  marginTop: '10px',
+                  border: '1px solid rgba(27,31,35,0.2)',
+                  borderRadius: '0.25em',
+                }}
+                labelStyle={{
+                  color: this.state.correctName
+                    ? '#fff'
+                    : 'rgba(203,36,49,0.4)',
+                  padding: '6px 12px',
+                  fontSize: '14px',
+                  fontWeight: '600',
+                  lineHeight: '20px',
+                  whiteSpace: 'nowrap',
+                  verticalAlign: 'middle',
+                }}
+                disabled={!this.state.correctName}
+              />
+            </div>
+          </div>
+        </Paper>
+      </div>
+    );
+  }
+}
+
+RemoveDeviceDialog.propTypes = {
+  onLoginSignUp: PropTypes.func,
+  devicename: PropTypes.string,
+  deviceIndex: PropTypes.number,
+  handleRemove: PropTypes.func,
+};
+
+export default RemoveDeviceDialog;

--- a/src/components/TableComplex/TableComplex.react.js
+++ b/src/components/TableComplex/TableComplex.react.js
@@ -192,7 +192,7 @@ export default class TableComplex extends Component {
                   }}
                 >
                   <TrashIcon
-                    onClick={() => this.props.handleRemove(index)}
+                    onClick={() => this.props.handleRemoveConfirmation(index)}
                     style={{ cursor: 'pointer' }}
                   />
                 </TableRowColumn>
@@ -211,5 +211,6 @@ TableComplex.propTypes = {
   stopEditing: PropTypes.func,
   handleChange: PropTypes.func,
   handleRemove: PropTypes.func,
+  handleRemoveConfirmation: PropTypes.func,
   editIdx: PropTypes.number,
 };


### PR DESCRIPTION
Partially solves #1361
- [x] Implement a confirmation dialog while removing devices

Changes: Now, for removing devices, user will have to enter the name of the device as a confirmation (as discussed in the meeting)

Demo Link: https://pr-1385-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![removedevicedialog2](https://user-images.githubusercontent.com/31135861/41893998-25e34e28-793b-11e8-93a3-855f494cbca5.gif)

