### PR TITLE
Fixes #1382: Only logged in users should see thumbs up/down

### DIFF
--- a/src/components/ChatApp/MessageListItem/Feedback.react.js
+++ b/src/components/ChatApp/MessageListItem/Feedback.react.js
@@ -6,6 +6,9 @@ import ShareIcon from 'material-ui/svg-icons/social/share';
 import UserPreferencesStore from '../../../stores/UserPreferencesStore';
 import * as Actions from '../../../actions/';
 import $ from 'jquery';
+import Cookies from 'universal-cookie';
+
+const cookies = new Cookies();
 
 class Feedback extends React.Component {
   // Parse skill meta data
@@ -128,7 +131,7 @@ class Feedback extends React.Component {
     let feedbackButtons = null;
     let feedbackStyle = {
       top: 5,
-      display: 'block',
+      display: 'flex',
       position: 'relative',
       float: 'right',
     };
@@ -164,16 +167,22 @@ class Feedback extends React.Component {
 
       feedbackButtons = (
         <span className="feedback" style={feedbackStyle}>
-          <ThumbUp
-            onClick={this.rateSkill.bind(this, 'positive')}
-            style={feedbackIndicator}
-            color={positiveFeedbackColor}
-          />
-          <ThumbDown
-            onClick={this.rateSkill.bind(this, 'negative')}
-            style={feedbackIndicator}
-            color={negativeFeedbackColor}
-          />
+          {cookies.get('loggedIn') ? (
+            <div>
+              <ThumbUp
+                onClick={this.rateSkill.bind(this, 'positive')}
+                style={feedbackIndicator}
+                color={positiveFeedbackColor}
+              />
+              <ThumbDown
+                onClick={this.rateSkill.bind(this, 'negative')}
+                style={feedbackIndicator}
+                color={negativeFeedbackColor}
+              />
+            </div>
+          ) : (
+            ''
+          )}
           <ShareIcon
             style={indicatorStyleShare}
             color={


### PR DESCRIPTION
Fixes #1382 

Changes: Thumbs up/down should be only visible to logged in users.

Demo Link: https://pr-1386-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
Logged in - 
![image](https://user-images.githubusercontent.com/21009455/41872236-d88068c0-78de-11e8-83dd-fa507de3f4b0.png)

Logged out - 
![image](https://user-images.githubusercontent.com/21009455/41872265-f842365c-78de-11e8-8f87-cbae0e2e6f31.png)
