### PR TITLE
Handled the case with Map view when no connected devices are there

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-linkify": "^0.2.1",
     "react-loading-animation": "^1.3.0",
     "react-modal": "^2.2.2",
-    "react-recaptcha": "^2.3.8",
+    "react-recaptcha": "^2.3.9",
     "react-render-html": "^0.5.0",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -1397,27 +1397,30 @@ class Settings extends Component {
                 style={{ height: '2px', marginBottom: '10px' }}
               />
             )}
-            <div>
-              <Tabs
-                onChange={this.handleTabSlide}
-                value={this.state.slideIndex}
-                inkBarStyle={{ background: 'rgb(66, 133, 244)', height: '5px' }}
-              >
-                <Tab label="Table View" value={0} style={styles.slide} />
-                <Tab label="Map View" value={1} style={styles.slide} />
-              </Tabs>
-              <div
-                style={{
-                  height: '10px',
-                }}
-              />
-              <SwipeableViews
-                index={this.state.slideIndex}
-                onChangeIndex={this.handleChange}
-              >
-                <div>
-                  <div style={{ overflowX: 'hidden' }}>
-                    {this.state.deviceData ? (
+            {this.state.deviceData ? (
+              <div>
+                <Tabs
+                  onChange={this.handleTabSlide}
+                  value={this.state.slideIndex}
+                  inkBarStyle={{
+                    background: 'rgb(66, 133, 244)',
+                    height: '5px',
+                  }}
+                >
+                  <Tab label="Table View" value={0} style={styles.slide} />
+                  <Tab label="Map View" value={1} style={styles.slide} />
+                </Tabs>
+                <div
+                  style={{
+                    height: '10px',
+                  }}
+                />
+                <SwipeableViews
+                  index={this.state.slideIndex}
+                  onChangeIndex={this.handleChange}
+                >
+                  <div>
+                    <div style={{ overflowX: 'hidden' }}>
                       <div
                         className="table"
                         style={{
@@ -1438,24 +1441,24 @@ class Settings extends Component {
                           tableData={this.state.obj}
                         />
                       </div>
-                    ) : (
-                      <div id="subheading">
-                        You do not have any devices connected yet !
-                      </div>
-                    )}
+                    </div>
                   </div>
-                </div>
 
-                <div style={{ maxHeight: '300px' }}>
-                  <MapContainer
-                    google={this.props.google}
-                    mapData={this.state.mapObj}
-                    centerLat={this.state.centerLat}
-                    centerLng={this.state.centerLng}
-                  />
-                </div>
-              </SwipeableViews>
-            </div>
+                  <div style={{ maxHeight: '300px' }}>
+                    <MapContainer
+                      google={this.props.google}
+                      mapData={this.state.mapObj}
+                      centerLat={this.state.centerLat}
+                      centerLng={this.state.centerLng}
+                    />
+                  </div>
+                </SwipeableViews>
+              </div>
+            ) : (
+              <div id="subheading">
+                You do not have any devices connected yet!
+              </div>
+            )}
           </div>
         </span>
       );

--- a/src/components/MapContainer/MapContainer.react.js
+++ b/src/components/MapContainer/MapContainer.react.js
@@ -58,6 +58,6 @@ export default class MapContainer extends Component {
 MapContainer.propTypes = {
   centerLat: PropTypes.number,
   centerLng: PropTypes.number,
-  mapData: PropTypes.object,
+  mapData: PropTypes.array,
   google: PropTypes.object,
 };


### PR DESCRIPTION
Fixes #1392 

Changes: Now the message `You do not have any devices connected yet!` is displayed instead of the Table view and Map view, when no connected devices are present. Currently, if no devices are there, then this message is displayed in the Table view, and a map with no markers is displayed in the Map view.

Demo Link: https://pr-1393-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
<img width="940" alt="screen shot 2018-06-28 at 12 35 42 pm" src="https://user-images.githubusercontent.com/31135861/42018465-cf733e72-7acf-11e8-972c-a769cf6f1006.png">
