### PR TITLE
Format code before running through ESLint checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,9 +93,9 @@
   },
   "lint-staged": {
     "src/**/*.js": [
-      "eslint src --ext .js",
       "prettier --write",
-      "git add"
+      "eslint --fix",
+      "git add ."
     ]
   }
 }


### PR DESCRIPTION
Fixes #1394 

Changes: Format code before running through ESLint checks which saves an extra step of using `npm run format` when ESLint checks fail.

Demo Link: https://pr-1395-fossasia-susi-web-chat.surge.sh
