### PR TITLE
Display device information on clicking the marker in the map

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -75,6 +75,9 @@ class Settings extends Component {
       deviceData: false,
       obj: [],
       mapObj: [],
+      devicenames: [],
+      rooms: [],
+      macids: [],
       editIdx: -1,
       removeDevice: -1,
       slideIndex: 0,
@@ -197,6 +200,9 @@ class Settings extends Component {
       success: function(response) {
         let obj = [];
         let mapObj = [];
+        let devicenames = [];
+        let rooms = [];
+        let macids = [];
         let centerLat = 0;
         let centerLng = 0;
         if (response.devices) {
@@ -220,6 +226,9 @@ class Settings extends Component {
             };
             obj.push(myObj);
             mapObj.push(location);
+            devicenames.push(response.devices[i].name);
+            rooms.push(response.devices[i].room);
+            macids.push(i);
             this.setState({
               dataFetched: true,
             });
@@ -237,6 +246,21 @@ class Settings extends Component {
               mapObj: mapObj,
               centerLat: centerLat,
               centerLng: centerLng,
+            });
+          }
+          if (devicenames.length) {
+            this.setState({
+              devicenames: devicenames,
+            });
+          }
+          if (rooms.length) {
+            this.setState({
+              rooms: rooms,
+            });
+          }
+          if (macids.length) {
+            this.setState({
+              macids: macids,
             });
           }
         }
@@ -1451,6 +1475,9 @@ class Settings extends Component {
                       mapData={this.state.mapObj}
                       centerLat={this.state.centerLat}
                       centerLng={this.state.centerLng}
+                      devicenames={this.state.devicenames}
+                      rooms={this.state.rooms}
+                      macids={this.state.macids}
                     />
                   </div>
                 </SwipeableViews>

--- a/src/components/MapContainer/MapContainer.react.js
+++ b/src/components/MapContainer/MapContainer.react.js
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
+// eslint-disable-next-line
+import { InfoWindow } from 'google-maps-react';
+
 import PropTypes from 'prop-types';
 
 export default class MapContainer extends Component {
@@ -27,6 +30,8 @@ export default class MapContainer extends Component {
       );
 
       this.map = new maps.Map(node, mapConfig);
+      let infoWindow = new google.maps.InfoWindow();
+      let i = 0;
 
       // Add markers to map
       this.props.mapData.forEach(location => {
@@ -34,8 +39,27 @@ export default class MapContainer extends Component {
         const marker = new google.maps.Marker({
           position: { lat: location.location.lat, lng: location.location.lng },
           map: this.map,
-          title: location.name,
+          title: 'Click to see device information.',
+          devicename: this.props.devicenames[i],
+          room: this.props.rooms[i],
+          macid: this.props.macids[i],
         });
+
+        google.maps.event.addListener(marker, 'click', function() {
+          infoWindow.setContent(
+            'Mac Address: ' +
+              marker.macid +
+              '<br/>' +
+              'Room: ' +
+              marker.room +
+              '<br/>' +
+              'Device name: ' +
+              marker.devicename,
+          );
+          infoWindow.open(this.map, marker);
+        });
+
+        i++;
       });
     }
   }
@@ -59,5 +83,8 @@ MapContainer.propTypes = {
   centerLat: PropTypes.number,
   centerLng: PropTypes.number,
   mapData: PropTypes.array,
+  devicenames: PropTypes.array,
+  rooms: PropTypes.array,
+  macids: PropTypes.array,
   google: PropTypes.object,
 };


### PR DESCRIPTION
Fixes #1399 

Changes: Now clicking on the markers in the map would display the device information. This way we can also figure out which marker corresponds to which device.

Demo Link: https://pr-1403-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![mapmarkerinfo2](https://user-images.githubusercontent.com/31135861/42113854-7405023c-7c0a-11e8-8902-50b340cb6420.gif)

