### PR TITLE
Fixed issues with the swipe gesture interfering with scrolling through Table View contents on mobile devices

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -1445,7 +1445,7 @@ class Settings extends Component {
                   onChangeIndex={this.handleChange}
                 >
                   <div>
-                    <div style={{ overflowX: 'hidden' }}>
+                    <div style={{ overflowX: 'auto' }}>
                       <div
                         className="table"
                         style={{


### PR DESCRIPTION
Fixes #1406 

Changes: Now the swipe gesture first scrolls through the Table View contents, and switches tabs only when we are at the extreme end of the Table View. This makes the Table View contents easily accessible on mobile devices.

Demo Link: https://pr-1407-fossasia-susi-web-chat.surge.sh

To test the changes: 
Add devices to your account and then check the Table View on your mobile device. You'll notice that currently (on chat.susi.ai) you aren't able to access the contents of the Table View as the overflow is set to 'hidden', but setting overflow to 'auto' (as done in this PR) makes the Table View contents accessible even on the mobile devices.

To add device to your account, make API calls like `https://api.susi.ai/aaa/addNewDevice.json?macid=8C-39-45-cc-eb-95&name=DeviceName&room=RoomName&latitude=52.34567&longitude=62.34567&access_token=yourAccessToken`
