### PR TITLE
Same top bar shadow everywhere

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -235,7 +235,7 @@ header{
   height: 46px;
   width: 100vw;
   background: #607d8b;
-  box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 3px 1px -2px rgba(0,0,0,.2), 0 1px 5px 0 rgba(0,0,0,.12);
+  box-shadow: 0 0 4px rgba(0,0,0,.14),0 4px 8px rgba(0,0,0,.28);
   user-select: none;
   -webkit-user-select: none;
 }


### PR DESCRIPTION
Partially fixes issue #1398

Changes: Applied same shadow for all top bars.

Demo Link: https://pr-1410-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

Top bar of overview page:
<img width="1154" alt="screen shot 2018-07-02 at 4 51 51 pm" src="https://user-images.githubusercontent.com/31174685/42161346-470bc972-7e18-11e8-8690-fe3b8889e528.png">


Before:
<img width="1155" alt="screen shot 2018-07-02 at 4 51 24 pm" src="https://user-images.githubusercontent.com/31174685/42161350-4a3028b4-7e18-11e8-96c0-c86e7964649c.png">

After:
<img width="1155" alt="screen shot 2018-07-02 at 4 51 41 pm" src="https://user-images.githubusercontent.com/31174685/42161351-4f44cc88-7e18-11e8-99fd-75acb954dfd2.png">


