### PR TITLE
Fixed issues with clicking of icons in settings

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -867,10 +867,12 @@ class Settings extends Component {
     return voiceOutput;
   };
 
-  loadSettings = e => {
+  loadSettings = (e, value) => {
     this.setDefaultsSettings(); // on every tab change, load the default settings
-    this.setState({ selectedSetting: e.target.innerText });
-    this.setState({ settingNo: e.target.innerText });
+    this.setState({
+      selectedSetting: window.innerWidth > 1060 ? value : e.target.innerText,
+      settingNo: e.target.innerText,
+    });
     //  Revert to original theme if user navigates away without saving.
     if (this.state.theme !== UserPreferencesStore.getTheme()) {
       this.setState({ theme: UserPreferencesStore.getTheme() }, () => {
@@ -1654,9 +1656,9 @@ class Settings extends Component {
       <div>
         <div className="settings-list">
           <Menu
-            onItemTouchTap={this.loadSettings}
             selectedMenuItemStyle={blueThemeColor}
             style={{ width: '100%' }}
+            onChange={this.loadSettings}
             value={this.state.selectedSetting}
           >
             <MenuItem
@@ -1870,9 +1872,9 @@ class Settings extends Component {
       <div>
         <div className="settings-list">
           <Menu
-            onItemTouchTap={this.loadSettings}
             selectedMenuItemStyle={blueThemeColor}
             style={{ width: '100%', height: '100%' }}
+            onChange={this.loadSettings}
             value={this.state.selectedSetting}
           >
             <MenuItem


### PR DESCRIPTION
Fixes #1416 

**Changes:** Now clicking on the icons for each tab displays the corresponding section on the right side.

**Demo Link:** https://pr-1418-fossasia-susi-web-chat.surge.sh

**Screenshots for the change:**

**Before:**
![settingsiconissuesold](https://user-images.githubusercontent.com/31135861/42334963-764fa358-809c-11e8-8df2-d3e28c8f9a34.gif)

**After:**
![settingsiconissuesnew](https://user-images.githubusercontent.com/31135861/42335000-8eb67b74-809c-11e8-8eea-cbdfecde8f80.gif)

