### PR TITLE
Fixes #1422: Add https to duckduckgo url

### DIFF
--- a/src/actions/API.actions.js
+++ b/src/actions/API.actions.js
@@ -198,7 +198,7 @@ export function createSUSIMessage(createdMessage, currentThreadID, voice) {
           }
           // Get RSS responses
           $.ajax({
-            url: 'http://api.duckduckgo.com/?format=json&q=' + query,
+            url: 'https://api.duckduckgo.com/?format=json&q=' + query,
             dataType: 'jsonp',
             crossDomain: true,
             timeout: 3000,


### PR DESCRIPTION
Fixes #1422 

Changes: [Add here what changes were made in this issue and if possible provide links.]
* Websearch is now working
*  Add https to duckduckgo url

Demo Link: https://pr-1423-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![screenshot from 2018-07-07 19-57-01](https://user-images.githubusercontent.com/12656846/42411797-f3070902-821f-11e8-9c0d-4f8bd8b83cb1.png)
