### PR TITLE
Speech output language not showing up in settings

### DIFF
--- a/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
+++ b/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
@@ -9,9 +9,11 @@ import FontIcon from 'material-ui/FontIcon';
 import DropDownMenu from 'material-ui/DropDownMenu';
 import MenuItem from 'material-ui/MenuItem';
 import Translate from '../../Translate/Translate.react';
+import injectTapEventPlugin from 'react-tap-event-plugin';
 
 class TextToSpeechSettings extends Component {
   constructor(props) {
+    injectTapEventPlugin();
     super(props);
     this.state = {
       rate: this.props.rate,


### PR DESCRIPTION
Fixes #1462

Changes: For me, on chrome it was working fine. But on firefox it was as reported by @mariobehling.
Material-Ui needs injectTapEventPlugin to create a 300ms tap delay(browsers are fixing/removing the click delay)

See the following stack overflow answer:
<img width="736" alt="screen shot 2018-07-17 at 3 55 32 pm" src="https://user-images.githubusercontent.com/18073126/42812036-f6df52f2-89d9-11e8-89b4-11a2cc376d51.png">

https://stackoverflow.com/questions/33541949/react-material-ui-dropdown-menu-not-working

This problem is solved in React 16.4, we can update our existing app, for time being this solution works.

Demo Link: https://pr-1462-fossasia-susi-web-chat.surge.sh
