### PR TITLE
Used automatic line break for text in Table response

### DIFF
--- a/src/components/ChatApp/MessageListItem/helperFunctions.react.js
+++ b/src/components/ChatApp/MessageListItem/helperFunctions.react.js
@@ -287,7 +287,17 @@ export function drawTable(columns, tableData, count) {
   }
   // Create the Table Header
   let tableheader = parseKeys.map((key, i) => {
-    return <TableHeaderColumn key={i}>{columns[key]}</TableHeaderColumn>;
+    return (
+      <TableHeaderColumn
+        key={i}
+        style={{
+          whiteSpace: 'normal',
+          wordWrap: 'break-word',
+        }}
+      >
+        {columns[key]}
+      </TableHeaderColumn>
+    );
   });
   // Calculate #rows in table
   let rowCount = tableData.length;
@@ -310,7 +320,13 @@ export function drawTable(columns, tableData, count) {
     if (validRow) {
       let rowcols = parseKeys.map((key, i) => {
         return (
-          <TableRowColumn key={i}>
+          <TableRowColumn
+            key={i}
+            style={{
+              whiteSpace: 'normal',
+              wordWrap: 'break-word',
+            }}
+          >
             <Linkify properties={{ target: '_blank' }}>
               <abbr title={eachrow[key]}>{processText(eachrow[key])}</abbr>
             </Linkify>
@@ -323,7 +339,7 @@ export function drawTable(columns, tableData, count) {
   // Populate the Table
   const table = (
     <MuiThemeProvider>
-      <Table selectable={false}>
+      <Table selectable={false} style={{ width: 'auto', tableLayout: 'auto' }}>
         <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
           {showColName && <TableRow>{tableheader}</TableRow>}
         </TableHeader>


### PR DESCRIPTION
Fixes #1466 

Changes: Removed horizontal scroll from Table responses by breaking text at the end of the window

Demo Link: https://pr-1469-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

Before:
![42904320-f77e1a58-8ad4-11e8-9c95-61ada60adf71](https://user-images.githubusercontent.com/31135861/42923323-9a1350c2-8b42-11e8-82c6-97b0bbdaab06.png)


After:
<img width="589" alt="screen shot 2018-07-19 at 10 55 07 am" src="https://user-images.githubusercontent.com/31135861/42923307-7d548e10-8b42-11e8-889d-51649f36f452.png">
