### PR TITLE
Fixes #1507: Turn the delete account button into warning color

### DIFF
--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -84,7 +84,7 @@
 }
 
 .Link a {
-  color : #1DA1F5;
+  color : #F44336;
   text-decoration : none;
 }
 


### PR DESCRIPTION
Fixes #1507
Changes: Quick CSS color update to more appropriate button color.

Demo Link: https://pr-1509-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/21009455/43818196-2371c926-9afb-11e8-98d7-6250a7c02052.png)
