### PR TITLE
Used https instead of http for duckduckgo API calls

### DIFF
--- a/src/actions/History.actions.js
+++ b/src/actions/History.actions.js
@@ -94,7 +94,7 @@ export function getHistory() {
 
         if (actions.indexOf('websearch') >= 0) {
           $.ajax({
-            url: 'http://api.duckduckgo.com/?format=json&q=' + query,
+            url: 'https://api.duckduckgo.com/?format=json&q=' + query,
             dataType: 'jsonp',
             crossDomain: true,
             timeout: 3000,


### PR DESCRIPTION
Ref: #1512 

Changes: Used `https` instead of `http` for duckduckgo API calls

Demo Link: https://pr-1516-fossasia-susi-web-chat.surge.sh