### PR TITLE
Pause all existing youtube videos when new one is created #1515

### DIFF
--- a/src/components/ChatApp/MessageListItem/MessageListItem.react.js
+++ b/src/components/ChatApp/MessageListItem/MessageListItem.react.js
@@ -47,6 +47,9 @@ class MessageListItem extends React.Component {
       height: 234,
     };
   }
+  _onReady = event => {
+    this.props.playerAdd(event);
+  };
 
   // Triggered when the voice player is started
   onStart = () => {
@@ -477,6 +480,7 @@ MessageListItem.propTypes = {
   markID: PropTypes.string,
   latestMessage: PropTypes.bool,
   latestUserMsgID: PropTypes.string,
+  playerAdd: PropTypes.func,
 };
 
 export default MessageListItem;

--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -34,6 +34,7 @@ function getStateFromStores() {
   }
   return {
     SnackbarOpen: false,
+    player: [],
     SnackbarOpenBackground: false,
     messages: MessageStore.getAllForCurrentThread(),
     thread: ThreadStore.getCurrent(),
@@ -76,12 +77,17 @@ function getStateFromStores() {
   };
 }
 
-function getMessageListItem(messages, showLoading, markID) {
+function getMessageListItem(messages, showLoading, addYouTube, markID) {
   // markID indicates search mode on
   if (markID) {
     return messages.map(message => {
       return (
-        <MessageListItem key={message.id} message={message} markID={markID} />
+        <MessageListItem
+          key={message.id}
+          message={message}
+          markID={markID}
+          playerAdd={addYouTube}
+        />
       );
     });
   }
@@ -107,6 +113,7 @@ function getMessageListItem(messages, showLoading, markID) {
           message={message}
           latestUserMsgID={latestUserMsgID}
           latestMessage={false}
+          playerAdd={addYouTube}
         />
       );
     }
@@ -116,6 +123,7 @@ function getMessageListItem(messages, showLoading, markID) {
         message={message}
         latestUserMsgID={latestUserMsgID}
         latestMessage={true}
+        playerAdd={addYouTube}
       />
     );
   });
@@ -197,6 +205,23 @@ class MessageSection extends Component {
       button: this.state.button.substring(1),
     };
   }
+
+  pauseAllVideos = () => {
+    this.state.player.forEach(event => {
+      try {
+        if (event.target.getPlayerState() === 1) {
+          event.target.pauseVideo();
+        }
+      } catch (error) {
+        // do nothing,
+      }
+    });
+  };
+
+  addYouTube = playerNew => {
+    this.pauseAllVideos();
+    this.setState(prevState => ({ player: [...prevState.player, playerNew] }));
+  };
 
   // Open Login Dialog
   handleOpen = () => {
@@ -612,11 +637,17 @@ class MessageSection extends Component {
     if (this.state.search) {
       let markID = this.state.searchState.scrollID;
       let markedMessages = this.state.searchState.markedMsgs;
-      messageListItems = getMessageListItem(markedMessages, false, markID);
+      messageListItems = getMessageListItem(
+        markedMessages,
+        false,
+        this.addYouTube,
+        markID,
+      );
     } else {
       messageListItems = getMessageListItem(
         this.state.messages,
         this.state.showLoading,
+        this.addYouTube,
       );
     }
 
@@ -967,7 +998,9 @@ class MessageSection extends Component {
    * Event handler for 'change' events coming from the MessageStore
    */
   _onChange() {
+    let array = this.state.player;
     this.setState(getStateFromStores());
+    this.setState({ player: array });
   }
 }
 


### PR DESCRIPTION
First steps for issue #1515

Changes: 
player state (an array) was added to MessageSection component. addYouTube function was created to add to the player state. addYouTube prop was passed down and bindings in getMessageListitems fucntion were changed for this. Created pauseAllVideos function to pause all playing videos. In MessageListitems component _onReady was created to call addYouTube.. 

net change is that MessageSection has an array which is called player which contains objects that have playVideo() and pauseVideo() functions defined and can be used to play and pause video.

Demo Link: https://pr-1534-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

![multipleyoutube gif](https://user-images.githubusercontent.com/33805964/44026653-5f86f598-9f11-11e8-8fb6-2907d2af9119.gif)
