### PR TITLE
Fixed issues with font colors in dark theme

### DIFF
--- a/src/components/Auth/ChangePassword/ChangePassword.react.js
+++ b/src/components/Auth/ChangePassword/ChangePassword.react.js
@@ -279,6 +279,7 @@ export default class ChangePassword extends Component {
       width: '30%',
       float: 'left',
       marginTop: '12px',
+      color: UserPreferencesStore.getTheme() === 'light' ? 'black' : 'white',
     };
     const inputStyle = {
       color: themeForegroundColor,

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -1257,6 +1257,7 @@ class Settings extends Component {
     const inputStyle = {
       height: '35px',
       marginBottom: '10px',
+      color: UserPreferencesStore.getTheme() === 'light' ? 'black' : 'white',
     };
     const fieldStyle = {
       height: '35px',

--- a/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
+++ b/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
@@ -170,7 +170,6 @@ class TextToSpeechSettings extends Component {
               marginBottom: '0px',
               fontSize: 15,
               fontWeight: 'bold',
-              color: 'rgba(0, 0, 0, 0.87)',
             }}
           >
             <Translate text="Speech Output Language" />
@@ -178,6 +177,10 @@ class TextToSpeechSettings extends Component {
           <DropDownMenu
             value={voiceOutput.voiceLang}
             onChange={this.handleTTSVoices}
+            labelStyle={{
+              color:
+                UserPreferencesStore.getTheme() === 'light' ? 'black' : 'white',
+            }}
           >
             {voiceOutput.voiceMenu}
           </DropDownMenu>
@@ -188,7 +191,6 @@ class TextToSpeechSettings extends Component {
               marginBottom: '0px',
               fontSize: 15,
               fontWeight: 'bold',
-              color: 'rgba(0, 0, 0, 0.87)',
             }}
           >
             <Translate text="Speech Output Rate" />
@@ -212,7 +214,6 @@ class TextToSpeechSettings extends Component {
               marginBottom: '0px',
               fontSize: 15,
               fontWeight: 'bold',
-              color: 'rgba(0, 0, 0, 0.87)',
             }}
           >
             <Translate text="Speech Output Pitch" />


### PR DESCRIPTION
Fixes #1538 

Changes: Fixed issues with font colors in dark theme.

Demo Link: https://pr-1539-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

Before:
<img width="215" alt="screen shot 2018-08-15 at 4 46 34 pm" src="https://user-images.githubusercontent.com/31135861/44146059-938037ba-a0ab-11e8-9af0-869ba2b1489a.png">

After:
<img width="238" alt="screen shot 2018-08-15 at 4 52 13 pm" src="https://user-images.githubusercontent.com/31135861/44146080-a42885a4-a0ab-11e8-85e2-70c74afa7790.png">
