### PR TITLE
Fix bug in signup form validation

### DIFF
--- a/src/components/Auth/SignUp/SignUp.react.js
+++ b/src/components/Auth/SignUp/SignUp.react.js
@@ -153,6 +153,9 @@ export default class SignUp extends Component {
       let validPassword = password.length >= 6;
       state.passwordValue = password;
       state.passwordError = !(password && validPassword);
+      state.passwordConfirmError = !(
+        password === this.state.confirmPasswordValue
+      );
       if (validPassword) {
         let result = zxcvbn(password);
         state.passwordScore = result.score;


### PR DESCRIPTION
Fixes #1371 

Changes: Fixed the bug - whenever a user enters same password on new password and verify password section and then changes the new password, the form validation is still set true.

Demo Link: https://pr-1542-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
Bug:
![b2](https://user-images.githubusercontent.com/30981465/44302645-09f92e00-a34b-11e8-8efe-d9a505c64cfd.png)

Fix:
![b1](https://user-images.githubusercontent.com/30981465/44302656-4167da80-a34b-11e8-9c4d-e035872048c8.png)

