### PR TITLE
Fixes Recaptcha console error message, XHR warning #1513

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
-    <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script> 
+    <script src="https://www.google.com/recaptcha/api.js?render=explicit" async defer></script> 
     <!--
       Notice the use of %PUBLIC_URL% in the tag above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@ $.ajax({
   dataType: 'json',
   crossDomain: true,
   timeout: 3000,
-  async: false,
+  async: true,
 }).done(function(output) {
   module.exports.MAP_KEY = output.keys.MAP_KEY;
   module.exports.CAPTCHA_KEY = output.keys.CAPTCHA_KEY;


### PR DESCRIPTION
By mistake, I rebased the commits before updating the branch for PR https://github.com/fossasia/chat.susi.ai/pull/1519

Fixes #1513 
Changes: 

Solves below 2:
1. Deprecation] Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/.
2. reCAPTCHA couldn't find user-provided function: onloadCallback

<img width="1200" alt="screen shot 2018-08-25 at 2 26 18 pm" src="https://user-images.githubusercontent.com/18073126/44616763-5bd21480-a873-11e8-9153-007b897ab36f.png">

Demo Link: https://pr-1513-fossasia-susi-web-chat.surge.sh (Updated)