### PR TITLE
StaticAppBar fixes

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.css
+++ b/src/components/StaticAppBar/StaticAppBar.css
@@ -58,3 +58,8 @@ a.drawerItem {
     margin-right: -8px;
     margin-top: 1px;
 }
+@media(max-width: 1000px){
+    .topRightLabel{
+        display: None;
+    }
+}

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -334,6 +334,7 @@ class StaticAppBar extends Component {
                 >
                   <CircleImage {...avatarProps} size="32" />
                   <label
+                    className="topRightLabel"
                     style={{
                       color: 'white',
                       marginRight: '5px',


### PR DESCRIPTION
Fixes #1549
Changes: 
Username disappears when screen width is less. This hinders the elements in StaticAppBar from overlapping each other when screen width is decreased

Demo Link: https://pr-1550-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![screen shot 2018-09-13 at 6 24 51 pm](https://user-images.githubusercontent.com/31539812/45490266-4b330100-b784-11e8-9862-7261886ed9d1.png)

