### PR TITLE
Buttons aligned

### DIFF
--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -98,7 +98,7 @@
 
 .settings-toggle {
   max-width: 5%;
-  float: left;
+  float: right;
 }
 
 .settingsSubmit{


### PR DESCRIPTION
Fixes #1554 

Changes: made float "right" in the settings-toggle class. This right aligns the buttons

Demo Link: https://pr-1555-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![1](https://user-images.githubusercontent.com/31557923/45745973-ac911f00-bc1f-11e8-879a-89091e4ffddd.png)
![2](https://user-images.githubusercontent.com/31557923/45745983-b6b31d80-bc1f-11e8-8d55-0e09fda248bb.png)
![3](https://user-images.githubusercontent.com/31557923/45745989-bca8fe80-bc1f-11e8-889f-816c7e2ff43a.png)



