### PR TITLE
Fixed radio buttons misalignment on decreasing screen size in Speech settings

### DIFF
--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -208,3 +208,9 @@
   width: 100%;
 }
 }
+
+@media screen and (max-width: 500px) {
+  .speechSettingDiv {
+    width: 70%;
+  }
+}

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -1409,6 +1409,7 @@ class Settings extends Component {
                 float: 'left',
                 padding: '0px 5px 0px 0px',
               }}
+              className="speechSettingDiv"
             >
               <Translate text="Enable speech output only for speech input" />
             </div>
@@ -1430,6 +1431,7 @@ class Settings extends Component {
                 fontSize: '15px',
                 fontWeight: 'bold',
               }}
+              className="speechSettingDiv"
             >
               <Translate text="Speech Output Always ON" />
             </div>
@@ -1439,6 +1441,7 @@ class Settings extends Component {
                 float: 'left',
                 padding: '5px 5px 0px 0px',
               }}
+              className="speechSettingDiv"
             >
               <Translate text="Enable speech output regardless of input type" />
             </div>

--- a/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
+++ b/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
@@ -168,9 +168,11 @@ class TextToSpeechSettings extends Component {
           <div
             style={{
               marginBottom: '0px',
+              marginTop: '15px',
               fontSize: 15,
               fontWeight: 'bold',
             }}
+            className="speechSettingDiv"
           >
             <Translate text="Speech Output Language" />
           </div>


### PR DESCRIPTION
Fixes #1560 

Changes: When screen size is decreased, the radio buttons aren't misaligned in the speech tab of the settings page.

Demo Link: https://pr-1561-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

![screenshot from 2018-09-21 01-38-14](https://user-images.githubusercontent.com/27884543/45844261-8662a080-bd3f-11e8-8932-ec85c9959c71.png)

@anshumanv @akshatnitd @Akshat-Jain  please review, Thanks!