### PR TITLE
Retain input tags order on resizing

### DIFF
--- a/src/components/Auth/ChangePassword/ChangePassword.css
+++ b/src/components/Auth/ChangePassword/ChangePassword.css
@@ -16,7 +16,6 @@
 }
 
 .forgot {
-  margin-left : 30%;
   margin-top : 5px;
   color : #1DA1F5;
 }

--- a/src/components/Auth/ChangePassword/ChangePassword.react.js
+++ b/src/components/Auth/ChangePassword/ChangePassword.react.js
@@ -276,10 +276,15 @@ export default class ChangePassword extends Component {
       width: '125%',
     };
     const labelStyle = {
-      width: '30%',
       float: 'left',
       marginTop: '12px',
       color: UserPreferencesStore.getTheme() === 'light' ? 'black' : 'white',
+      minWidth: '30%',
+      width: '150px',
+    };
+    const forgotPassLink = {
+      minWidth: '300px',
+      margin: '-20 auto',
     };
     const inputStyle = {
       color: themeForegroundColor,
@@ -296,6 +301,7 @@ export default class ChangePassword extends Component {
             <div>
               <PasswordField
                 name="password"
+                position="relative"
                 style={fieldStyle}
                 value={this.state.passwordValue}
                 onChange={this.handleChange}
@@ -306,17 +312,14 @@ export default class ChangePassword extends Component {
                 visibilityButtonStyle={{ display: 'none' }}
                 visibilityIconStyle={{ display: 'none' }}
               />
-              <div className="forgot">
-                <a href={`${urls.ACCOUNT_URL}/forgotpwd`}>
-                  Forgot your password?
-                </a>
-              </div>
             </div>
             <br />
             <div style={labelStyle}>New Password</div>
             <div className={PasswordClass.join(' ')}>
               <PasswordField
                 name="newPassword"
+                position="relative"
+                placeholder="Must be at least 6 characters"
                 style={fieldStyle}
                 value={this.state.newPasswordValue}
                 onChange={this.handleChange}
@@ -335,6 +338,8 @@ export default class ChangePassword extends Component {
             <div>
               <PasswordField
                 name="confirmNewPassword"
+                position="relative"
+                placeholder="Must match the new password"
                 style={fieldStyle}
                 value={this.state.confirmNewPasswordValue}
                 onChange={this.handleChange}
@@ -346,7 +351,13 @@ export default class ChangePassword extends Component {
                 visibilityIconStyle={{ display: 'none' }}
               />
             </div>
-            <div>
+            <div style={forgotPassLink}>
+              <br />
+              <div className="forgot">
+                <a href={`${urls.ACCOUNT_URL}/forgotpwd`}>
+                  Forgot your password?
+                </a>
+              </div>
               <br />
               <RaisedButton
                 label={<Translate text="Save Changes" />}

--- a/src/components/ChatApp/Settings/PreviewThemeChat.css
+++ b/src/components/ChatApp/Settings/PreviewThemeChat.css
@@ -42,12 +42,6 @@
     justify-content: space-between;
 }
 
-.susi-logo{
-    width:50px;
-    height: 10px;
-    margin-left:10px;
-}
-
 .chat-input{
     padding: 0 20px 0 5px;
     border: none;

--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -208,3 +208,9 @@
   width: 100%;
 }
 }
+
+@media screen and (max-width: 500px) {
+  .speechSettingDiv {
+    width: 70%;
+  }
+}

--- a/src/components/ChatApp/Settings/Settings.css
+++ b/src/components/ChatApp/Settings/Settings.css
@@ -210,7 +210,7 @@
 }
 
 @media screen and (max-width: 500px) {
-  .speechSettingDiv {
+  .reduceSettingDiv {
     width: 70%;
   }
 }

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -1294,6 +1294,7 @@ class Settings extends Component {
               )}
               <br />
               <div
+                className="reduceSettingDiv"
                 style={{
                   float: 'left',
                   padding: '0px 5px 0px 0px',
@@ -1409,7 +1410,7 @@ class Settings extends Component {
                 float: 'left',
                 padding: '0px 5px 0px 0px',
               }}
-              className="speechSettingDiv"
+              className="reduceSettingDiv"
             >
               <Translate text="Enable speech output only for speech input" />
             </div>
@@ -1431,7 +1432,7 @@ class Settings extends Component {
                 fontSize: '15px',
                 fontWeight: 'bold',
               }}
-              className="speechSettingDiv"
+              className="reduceSettingDiv"
             >
               <Translate text="Speech Output Always ON" />
             </div>
@@ -1441,7 +1442,7 @@ class Settings extends Component {
                 float: 'left',
                 padding: '5px 5px 0px 0px',
               }}
-              className="speechSettingDiv"
+              className="reduceSettingDiv"
             >
               <Translate text="Enable speech output regardless of input type" />
             </div>
@@ -1840,6 +1841,7 @@ class Settings extends Component {
               float: 'left',
               padding: '0px 5px 0px 0px',
             }}
+            className="reduceSettingDiv"
           >
             <Translate text="Send message by pressing ENTER" />
           </div>

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -1409,6 +1409,7 @@ class Settings extends Component {
                 float: 'left',
                 padding: '0px 5px 0px 0px',
               }}
+              className="speechSettingDiv"
             >
               <Translate text="Enable speech output only for speech input" />
             </div>
@@ -1430,6 +1431,7 @@ class Settings extends Component {
                 fontSize: '15px',
                 fontWeight: 'bold',
               }}
+              className="speechSettingDiv"
             >
               <Translate text="Speech Output Always ON" />
             </div>
@@ -1439,6 +1441,7 @@ class Settings extends Component {
                 float: 'left',
                 padding: '5px 5px 0px 0px',
               }}
+              className="speechSettingDiv"
             >
               <Translate text="Enable speech output regardless of input type" />
             </div>

--- a/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
+++ b/src/components/ChatApp/Settings/TextToSpeechSettings.react.js
@@ -168,9 +168,11 @@ class TextToSpeechSettings extends Component {
           <div
             style={{
               marginBottom: '0px',
+              marginTop: '15px',
               fontSize: 15,
               fontWeight: 'bold',
             }}
+            className="speechSettingDiv"
           >
             <Translate text="Speech Output Language" />
           </div>

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -58,11 +58,11 @@
     justify-content: space-between
 }
 .susi-logo{
-    margin: 10px 0;
-    height: 30px;
+    height: 10px;
     vertical-align: middle;
     max-width: 100px;
-    display: inline-block;
+    margin-top: 21px;
+    width: auto;
 }
 
 @media only screen and (min-width: 1400px){
@@ -97,5 +97,9 @@
         text-overflow: ellipsis;
         display: block;
     }
+    .susi-logo{
+      display: block;
+      margin-left:auto;
+      margin-right: auto;
+    }
 }
-


### PR DESCRIPTION
Fixes #1557 

Demo Link: https://pr-1562-fossasia-susi-web-chat.surge.sh

I've placed the forgot password link above the "Save Changes" button. Elements are properly arranged when screen is resized.

Screenshots for the change: 

![screen shot 2018-09-21 at 3 17 11 am](https://user-images.githubusercontent.com/31539812/45848644-e14ec480-bd4c-11e8-8daa-09e6e794689e.png)

