### PR TITLE
Remove 'Get started today' banner when logged in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /build
 
 # misc
+.idea
 .DS_Store
 .env
 npm-debug.log*

--- a/src/components/Support/Support.react.js
+++ b/src/components/Support/Support.react.js
@@ -1,6 +1,7 @@
 import './Support.css';
 import $ from 'jquery';
 import Close from 'material-ui/svg-icons/navigation/close';
+import Cookies from 'universal-cookie';
 import code from '../../images/code.png';
 import Dialog from 'material-ui/Dialog';
 import documentation from '../../images/programmer.png';
@@ -18,6 +19,8 @@ import support from '../../images/support.png';
 import question from '../../images/question.png';
 import React, { Component } from 'react';
 import urls from '../../utils/urls';
+
+const cookies = new Cookies();
 
 class Support extends Component {
   constructor(props) {
@@ -285,19 +288,22 @@ class Support extends Component {
           </div>
         </div>
         <div className="blue-wrapper">
-          <div className="non-flex blue-background">
-            <div className="conversation__description footer-desc">
-              <div className="support__heading center blue-text">
-                Get Started Today
-              </div>
+          {!cookies.get('loggedIn') ? (
+            <div className="non-flex blue-background">
+              <div className="conversation__description footer-desc">
+                <div className="support__heading center blue-text">
+                  Get Started Today
+                </div>
 
-              <RaisedButton
-                label="Sign Up"
-                onTouchTap={this.handleSignUp}
-                style={style}
-              />
+                <RaisedButton
+                  label="Sign Up"
+                  onTouchTap={this.handleSignUp}
+                  style={style}
+                />
+              </div>
             </div>
-          </div>
+          ) : null}
+
           <Footer />
         </div>
 


### PR DESCRIPTION
Fixes #1570 

Changes: 'Get started today' banner doesn't show up now when user is logged in.

Demo Link: https://pr-1572-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
When logged in:
![screenshot from 2018-09-22 23-58-40](https://user-images.githubusercontent.com/21025052/45920560-75429c80-bec3-11e8-8db2-b4b9c0fa6f1b.png)

When not logged in:
![screenshot from 2018-09-23 00-03-31](https://user-images.githubusercontent.com/21025052/45920597-25b0a080-bec4-11e8-9ec6-06f698f50421.png)

