### PR TITLE
Edit theme disabled for light and dark theme

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -1135,6 +1135,13 @@ class Settings extends Component {
     return somethingToSave;
   };
 
+  getSomethingToEdit = () => {
+    let somethingToEdit = false;
+    if (this.state.theme === 'custom') {
+      somethingToEdit = true;
+    }
+    return somethingToEdit;
+  };
   handleCountryChange = (event, index, value) => {
     this.setState({
       countryCode: value,
@@ -1269,6 +1276,7 @@ class Settings extends Component {
     };
 
     let currentSetting;
+    let somethingToEdit = this.getSomethingToEdit();
 
     let voiceOutput = this.populateVoiceList();
     if (this.state.selectedSetting === 'Microphone') {
@@ -1374,6 +1382,7 @@ class Settings extends Component {
           </RadioButtonGroup>
           <RaisedButton
             label={<Translate text="Edit theme" />}
+            disabled={!somethingToEdit}
             backgroundColor="#4285f4"
             labelColor="#fff"
             onClick={this.handleThemeChanger}


### PR DESCRIPTION
Fixes #1577 

Changes: Edit theme is disabled when the theme chosen is light/dark

Demo Link: https://pr-[ADD_PULL_REQUEST_NUMBER_HERE]-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

![2018-09-23 5](https://user-images.githubusercontent.com/31557923/45927388-20993300-bf50-11e8-80d8-e393fd8f8e96.png)
![2018-09-23 6](https://user-images.githubusercontent.com/31557923/45927392-25f67d80-bf50-11e8-804c-f5dbd123b2ed.png)
![2018-09-23 7](https://user-images.githubusercontent.com/31557923/45927394-2bec5e80-bf50-11e8-9b0e-5e337b533e4a.png)



