### PR TITLE
edit theme disabled for light/dark theme

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -1375,6 +1375,7 @@ class Settings extends Component {
           </RadioButtonGroup>
           <RaisedButton
             label={<Translate text="Edit theme" />}
+            disabled={this.state.theme !== 'custom'}
             backgroundColor="#4285f4"
             labelColor="#fff"
             onClick={this.handleThemeChanger}


### PR DESCRIPTION
Fixes #1577 

Changes: Edit theme is disabled when the theme chosen is light/dark

Demo Link: https://pr-1581-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

![2018-09-23 11](https://user-images.githubusercontent.com/31557923/45930428-d2028d80-bf7d-11e8-93d7-9def13df5c05.png)
![2018-09-23 12](https://user-images.githubusercontent.com/31557923/45930430-dcbd2280-bf7d-11e8-8b73-488dfa255d02.png)
![2018-09-23 14](https://user-images.githubusercontent.com/31557923/45930433-e181d680-bf7d-11e8-8d37-9e7fecd0c0d0.png)



