### PR TITLE
The next button on the blog page gets aligned properly when screen is squeezed

### DIFF
--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -3,6 +3,7 @@
     width: 100%;
     position: relative;
     z-index: 10;
+    max-height: 150px;
 }
 .footer-container a{
     text-decoration: none;


### PR DESCRIPTION
Fixes #1584 

Changes: The next button at the bottom of the blog page gets aligned properly when screen is squeezed

Demo Link: https://pr-1586-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![footet](https://user-images.githubusercontent.com/32234926/45992730-045cd980-c0a9-11e8-988c-437e6b2d2d0a.PNG)

