### PR TITLE
Remove min password character limit warning when logging in (#1582)

### DIFF
--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -193,9 +193,8 @@ class Login extends Component {
       state.emailError = !(email && validEmail);
     } else if (event.target.name === 'password') {
       password = event.target.value;
-      let validPassword = password.length >= 6;
       state.password = password;
-      state.passwordError = !(password && validPassword);
+      state.passwordError = !password;
     }
     if (this.state.emailError) {
       this.emailErrorMessage = 'Enter a valid Email Address';
@@ -203,7 +202,7 @@ class Login extends Component {
       this.emailErrorMessage = '';
     }
     if (this.state.passwordError) {
-      this.passwordErrorMessage = 'Minimum 6 characters required';
+      this.passwordErrorMessage = 'Enter a valid Password';
     } else {
       this.passwordErrorMessage = '';
     }


### PR DESCRIPTION
Fixes #1582 

Changes: 
1. Removed the check for min password character limit
2. Warning message changed to "Enter a valid password" (showed only when password field is empty)

Demo Link: https://pr-1589-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/31558262/46018238-08afe380-c0f7-11e8-8a1c-df9c70039b3d.png)

