### PR TITLE
fixed background change of settings-menu even when theme is not selected

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -772,8 +772,8 @@ class Settings extends Component {
   // Handle change to theme settings
   handleSelectChange = (event, value) => {
     value === 'light' || value === 'custom'
-      ? ($('#settings-container').addClass({"class":"settings-container-light"}))
-      : ($('#settings-container').addClass({"class":"settings-container-dark"}));
+      ? ($('#settings-container').addClass({ 'class': 'settings-container-light' }))
+      : ($('#settings-container').addClass({ 'class': 'settings-container-dark' }));
     this.preview = true;
     this.setState({ theme: value }, () => {
       this.handleSubmit();
@@ -2223,7 +2223,7 @@ class Settings extends Component {
       <div
         id="settings-container"
         className={
-          (UserPreferencesStore.getTheme() === 'light' && this.state.settingNo!=='Theme') || (this.state.settingNo==='Theme' && this.state.theme==='light')
+          (UserPreferencesStore.getTheme() === 'light' && this.state.settingNo !== 'Theme') || (this.state.settingNo === 'Theme' && this.state.theme === 'light')
             ? 'settings-container-light'
             : 'settings-container-dark'
         }

--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -772,10 +772,8 @@ class Settings extends Component {
   // Handle change to theme settings
   handleSelectChange = (event, value) => {
     value === 'light' || value === 'custom'
-      ? (document.getElementById('settings-container').style.background =
-          'rgb(242, 242, 242)')
-      : (document.getElementById('settings-container').style.background =
-          'rgb(0,0,18)');
+      ? ($('#settings-container').addClass({"class":"settings-container-light"}))
+      : ($('#settings-container').addClass({"class":"settings-container-dark"}));
     this.preview = true;
     this.setState({ theme: value }, () => {
       this.handleSubmit();
@@ -2225,7 +2223,7 @@ class Settings extends Component {
       <div
         id="settings-container"
         className={
-          UserPreferencesStore.getTheme() === 'light'
+          (UserPreferencesStore.getTheme() === 'light' && this.state.settingNo!=='Theme') || (this.state.settingNo==='Theme' && this.state.theme==='light')
             ? 'settings-container-light'
             : 'settings-container-dark'
         }


### PR DESCRIPTION
Fixes #1587 

Changes: Now the background of settings-menu doesn't change even if we select another theme and move to another setting.

Demo Link: https://pr-1592-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
Initially, the theme was light
![screenshot 64](https://user-images.githubusercontent.com/28647524/46155591-4a769080-c295-11e8-988e-cc13c3f85020.png)

Now, I switch to dark theme but I don't save it
![screenshot 65](https://user-images.githubusercontent.com/28647524/46155640-6843f580-c295-11e8-99fd-cd885d7ea0fd.png)

Now, when I switch to some other setting, the background is same as of light theme.
![screenshot 66](https://user-images.githubusercontent.com/28647524/46155681-814ca680-c295-11e8-9aac-66632e412ac8.png)

Same happens with dark theme:
![screenshot 67](https://user-images.githubusercontent.com/28647524/46155763-b0631800-c295-11e8-86c5-3f120124ded1.png)

![screenshot 68](https://user-images.githubusercontent.com/28647524/46155777-b953e980-c295-11e8-8d76-f943812fa5a1.png)

![screenshot 69](https://user-images.githubusercontent.com/28647524/46155793-bfe26100-c295-11e8-9dfe-25070a433cf1.png)
