### PR TITLE
fixed background change in settings-menu when theme gets changed

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -772,10 +772,8 @@ class Settings extends Component {
   // Handle change to theme settings
   handleSelectChange = (event, value) => {
     value === 'light' || value === 'custom'
-      ? (document.getElementById('settings-container').style.background =
-          'rgb(242, 242, 242)')
-      : (document.getElementById('settings-container').style.background =
-          'rgb(0,0,18)');
+      ? $('#settings-container').addClass('settings-container-light')
+      : $('#settings-container').addClass('settings-container-dark');
     this.preview = true;
     this.setState({ theme: value }, () => {
       this.handleSubmit();
@@ -2225,7 +2223,9 @@ class Settings extends Component {
       <div
         id="settings-container"
         className={
-          UserPreferencesStore.getTheme() === 'light'
+          (UserPreferencesStore.getTheme() === 'light' &&
+            this.state.settingNo !== 'Theme') ||
+          (this.state.settingNo === 'Theme' && this.state.theme === 'light')
             ? 'settings-container-light'
             : 'settings-container-dark'
         }


### PR DESCRIPTION
Fixes #1587 

Changes: Background colour behind settings-menu doesn't change now if another theme was selected other than current theme.

Demo Link: https://pr-1593-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
Initially, the theme was light
![screenshot 64](https://user-images.githubusercontent.com/28647524/46163623-510f0300-c2a9-11e8-8049-11bfaac43622.png)

Now I selected dark theme radiobutton but didn't saved changes
![screenshot 65](https://user-images.githubusercontent.com/28647524/46163675-726fef00-c2a9-11e8-9cbf-3ee7c62189a7.png)

Now when I move to other setting, the bakground remains same of light theme
![screenshot 66](https://user-images.githubusercontent.com/28647524/46163712-89aedc80-c2a9-11e8-958a-205c48bb6639.png)

Same happens in the case of dark theme
![screenshot 67](https://user-images.githubusercontent.com/28647524/46163730-96cbcb80-c2a9-11e8-9edd-55c4baae64a8.png)

![screenshot 68](https://user-images.githubusercontent.com/28647524/46163740-9b907f80-c2a9-11e8-8811-2c47d24f9011.png)

![screenshot 69](https://user-images.githubusercontent.com/28647524/46163749-a0edca00-c2a9-11e8-9efa-5e5a3600450e.png)
