### PR TITLE
Removed red outline on logo onClick-Solves issue(#1588)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-url-query": "1.4.0",
     "react-youtube": "7.6.0",
     "redux": "^3.7.2",
-    "surge": "0.19.0",
+    "surge": "^0.20.1",
     "universal-cookie": "2.2.0",
     "zxcvbn": "4.4.2"
   },

--- a/src/components/ChatApp/TopBar.react.js
+++ b/src/components/ChatApp/TopBar.react.js
@@ -255,8 +255,8 @@ class TopBar extends Component {
         }}
       >
         <ToolbarGroup>
-          <div style={{ float: 'left', marginTop: '0px' }}>
-            <Link to="/">
+          <div style={{ float: 'left', marginTop: '0px', outline: '0' }}>
+            <Link to="/" style={{ outline: '0' }}>
               <img src={susiWhite} alt="susi-logo" style={logoStyle} />
             </Link>
           </div>


### PR DESCRIPTION
Fixes #1588 

Changes: 
The red outline that appeared on the logo on click does not appear now
Demo-Link:  http://1596-fossasia-susi-web-chat.surge.sh/

GIF for the change: 
![chat-susi](https://user-images.githubusercontent.com/34754265/46246055-846ea080-c415-11e8-914b-1239d9d59dfa.gif)

