### PR TITLE
Text input displays in custom theme and TypeError resolved-(Solves issue#1605)

### DIFF
--- a/src/components/ChatApp/Settings/Settings.react.js
+++ b/src/components/ChatApp/Settings/Settings.react.js
@@ -700,10 +700,10 @@ class Settings extends Component {
     let checked = this.state.checked;
     let serverUrl = this.state.serverUrl;
     let newCountryCode = !this.state.countryCode
-      ? this.intialSettings.countryCode
+      ? this.state.intialSettings.countryCode
       : this.state.countryCode;
     let newCountryDialCode = !this.state.countryDialCode
-      ? this.intialSettings.countryDialCode
+      ? this.state.intialSettings.countryDialCode
       : this.state.countryDialCode;
     let newPhoneNo = this.state.PhoneNo;
     if (newDefaultServer.slice(-1) === '/') {
@@ -1257,7 +1257,7 @@ class Settings extends Component {
     const inputStyle = {
       height: '35px',
       marginBottom: '10px',
-      color: UserPreferencesStore.getTheme() === 'light' ? 'black' : 'white',
+      color: UserPreferencesStore.getTheme() === 'dark' ? 'white' : 'black',
     };
     const fieldStyle = {
       height: '35px',


### PR DESCRIPTION
Fixes #1605 

Changes: Username and Email gets displayed in Custom Theme as well
`this.intialSettings` undefined type error is resolved

Demo Link: http://pr-number-1606-fossasia-susi-web-chat.surge.sh/

Screenshots for the change: 
![screenshot from 2018-10-03 01-04-33](https://user-images.githubusercontent.com/34754265/46372293-594faf80-c6a8-11e8-87a1-bf71eab43922.png)

GIF of the changes: 
![chat susi-2](https://user-images.githubusercontent.com/34754265/46372441-ca8f6280-c6a8-11e8-8c4d-e89f47f33856.gif)


