### PR TITLE
Modify next and previous button in search bar

### DIFF
--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -903,11 +903,34 @@ class MessageSection extends Component {
         searchState: currState,
       });
     }
-    if (markedIDs && ul && newIndex <= 0) {
+    if (markedIDs && ul && newIndex === 0) {
       let currState = this.state.searchState;
       newIndex = indexLimit;
       currState.scrollIndex = newIndex;
       currState.searchIndex = 1;
+    }
+    if (markedIDs && ul && newIndex < 0) {
+      let currState = this.state.searchState;
+      newIndex = indexLimit;
+      currState.scrollIndex = newIndex;
+      currState.searchIndex = 1;
+      newIndex = this.state.searchState.scrollIndex - 1;
+      newSearchCount = this.state.searchState.searchIndex - 1;
+      markedIDs = this.state.searchState.markedIDs;
+      indexLimit = this.state.searchState.scrollLimit;
+      ul = this.messageList;
+      if (newSearchCount <= 0) {
+        newSearchCount = indexLimit;
+      }
+      if (markedIDs && ul && newIndex >= 0) {
+        currState = this.state.searchState;
+        currState.scrollIndex = newIndex;
+        currState.searchIndex = newSearchCount;
+        currState.scrollID = markedIDs[newIndex];
+        this.setState({
+          searchState: currState,
+        });
+      }
     }
   };
 

--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -873,13 +873,27 @@ class MessageSection extends Component {
         searchState: currState,
       });
     }
+    if (markedIDs && ul && newIndex === indexLimit) {
+      let currState = this.state.searchState;
+      newIndex = 0;
+      currState.scrollIndex = newIndex;
+      currState.searchIndex = 1;
+      currState.scrollID = markedIDs[newIndex];
+      this.setState({
+        searchState: currState,
+      });
+    }
   };
 
   _onClickRecent = () => {
     let newIndex = this.state.searchState.scrollIndex - 1;
     let newSearchCount = this.state.searchState.searchIndex - 1;
     let markedIDs = this.state.searchState.markedIDs;
+    let indexLimit = this.state.searchState.scrollLimit;
     let ul = this.messageList;
+    if (newSearchCount === 0) {
+      newSearchCount = indexLimit;
+    }
     if (markedIDs && ul && newIndex >= 0) {
       let currState = this.state.searchState;
       currState.scrollIndex = newIndex;
@@ -888,6 +902,12 @@ class MessageSection extends Component {
       this.setState({
         searchState: currState,
       });
+    }
+    if (markedIDs && ul && newIndex === 0) {
+      let currState = this.state.searchState;
+      newIndex = indexLimit;
+      currState.scrollIndex = newIndex;
+      currState.searchIndex = 1;
     }
   };
 

--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -891,7 +891,7 @@ class MessageSection extends Component {
     let markedIDs = this.state.searchState.markedIDs;
     let indexLimit = this.state.searchState.scrollLimit;
     let ul = this.messageList;
-    if (newSearchCount === 0) {
+    if (newSearchCount <= 0) {
       newSearchCount = indexLimit;
     }
     if (markedIDs && ul && newIndex >= 0) {
@@ -903,7 +903,7 @@ class MessageSection extends Component {
         searchState: currState,
       });
     }
-    if (markedIDs && ul && newIndex === 0) {
+    if (markedIDs && ul && newIndex <= 0) {
       let currState = this.state.searchState;
       newIndex = indexLimit;
       currState.scrollIndex = newIndex;


### PR DESCRIPTION
Fixes #1612 

Changes: When search is at last index and after that clicking the next button , the search start from starting . Similarly for previous button.

Demo Link: https://pr-1613-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![search1](https://user-images.githubusercontent.com/32234926/46742135-07b8ad80-ccc4-11e8-81cd-1eb1013d2987.gif)

