### PR TITLE
Placeholder text added in password tab fields

### DIFF
--- a/src/components/Auth/ChangePassword/ChangePassword.react.js
+++ b/src/components/Auth/ChangePassword/ChangePassword.react.js
@@ -319,6 +319,7 @@ export default class ChangePassword extends Component {
             <div className={PasswordClass.join(' ')}>
               <PasswordField
                 name="newPassword"
+                placeholder="Must be at least 6 characters"
                 style={fieldStyle}
                 value={this.state.newPasswordValue}
                 onChange={this.handleChange}
@@ -337,6 +338,7 @@ export default class ChangePassword extends Component {
             <div>
               <PasswordField
                 name="confirmNewPassword"
+                placeholder="Must match the new password"
                 style={fieldStyle}
                 value={this.state.confirmNewPasswordValue}
                 onChange={this.handleChange}


### PR DESCRIPTION
Fixes #1624 
 
Changes: Placeholder text added in password tab fields

Demo Link: https://pr-1625-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

![screenshot 2018-10-18 at 9 10 34 pm](https://user-images.githubusercontent.com/31539812/47166686-614f5680-d31a-11e8-846e-b83421f197d5.png)
