### PR TITLE
Fixes field text color  in password tab (default custom theme)

### DIFF
--- a/src/components/Auth/ChangePassword/ChangePassword.react.js
+++ b/src/components/Auth/ChangePassword/ChangePassword.react.js
@@ -280,7 +280,11 @@ export default class ChangePassword extends Component {
       minWidth: '150px',
       float: 'left',
       marginTop: '12px',
-      color: UserPreferencesStore.getTheme() === 'light' ? 'black' : 'white',
+      color:
+        UserPreferencesStore.getTheme() === 'light' ||
+        UserPreferencesStore.getTheme() === 'custom'
+          ? 'black'
+          : 'white',
     };
     const submitBtnStyle = {
       float: 'left',


### PR DESCRIPTION
** Fixes #1635 **

Changes: Updated color check for custom theme in src/components/Auth/ChangePassword/ChangePassword.react.js

Demo Link: https://pr-1636-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

![updatedcolorbug](https://user-images.githubusercontent.com/16002727/47268561-3d854e00-d570-11e8-9b3b-1fa0ee40c9d4.png)

