### PR TITLE
Fixes #1637: vscode is not present in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ yarn-error.log*
 jest
 ..env.swp
 package-lock.json
+.vscode/


### PR DESCRIPTION
Fixes #1637 

Changes: Added .vscode into `.gitignore`.
Demo Link: https://pr-1638-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
