### PR TITLE
Moved Close Button in Video

### DIFF
--- a/src/components/Overview/Overview.css
+++ b/src/components/Overview/Overview.css
@@ -240,7 +240,7 @@ img {
     top: 46px;
     left: 40px;
     right: 40px;
-    background-color: #fff;
+    background-color: #000;
     width: 75%;
     margin: 0 auto;
     box-shadow: 0 0 60px rgba(0, 0, 0, 0.07);
@@ -275,9 +275,9 @@ img {
 .video-container embed {
     position: absolute;
     top: 0;
-    left: 0;
+    left: 5%;
     border: 0;
-    width: 100%;
+    width: 90%;
     height: 100%;
 }
 

--- a/src/components/Overview/Overview.react.js
+++ b/src/components/Overview/Overview.react.js
@@ -73,7 +73,7 @@ class Overview extends Component {
       fill: '#fff',
       width: '40px',
       height: '40px',
-      right: '20px',
+      right: '1.5%',
       top: '20px',
       cursor: 'pointer',
     };


### PR DESCRIPTION
Fixes #1647 

Changes: 

- Adds black space to sides of video to allow the close button to show up
- Moves the close button to the side so that it no longer overlaps with the video

Demo Link: https://pr-1649-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

![image](https://user-images.githubusercontent.com/8119928/47537830-08416e80-d896-11e8-99d2-9b679cd76319.png)
