### PR TITLE
Fixed email validation on signup page

### DIFF
--- a/src/components/Auth/SignUp/SignUp.react.js
+++ b/src/components/Auth/SignUp/SignUp.react.js
@@ -144,11 +144,12 @@ export default class SignUp extends Component {
     let state = this.state;
     if (event.target.name === 'email') {
       email = event.target.value.trim();
-      let validEmail = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(email);
+      let validEmail = email.length >= 1;
       state.email = email;
       state.isEmail = validEmail;
-      state.emailError = !(email || validEmail);
-    } else if (event.target.name === 'password') {
+      state.emailError = !(email && validEmail);
+    }
+    if (event.target.name === 'password') {
       password = event.target.value;
       let validPassword = password.length >= 6;
       state.passwordValue = password;
@@ -186,7 +187,7 @@ export default class SignUp extends Component {
     this.setState(state);
 
     if (this.state.emailError) {
-      this.emailErrorMessage = 'Enter a valid Email Address';
+      this.emailErrorMessage = 'Enter a Email Address';
     } else if (this.state.passwordError) {
       this.emailErrorMessage = '';
       this.passwordErrorMessage = 'Minimum 6 characters required';


### PR DESCRIPTION
Fixes #1660 

Changes: 

- When typing the wrong email in the email textfield error is shown.
- On signing up using an invalid email address, Signup button will not work.

 

Demo Link: https://pr-1661-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![email validation](https://user-images.githubusercontent.com/32234926/47611150-7304cc80-da85-11e8-9bf6-9ec275c82064.gif)


