### PR TITLE
Minimum password length warning removed from the Current password field

### DIFF
--- a/src/components/Auth/ChangePassword/ChangePassword.react.js
+++ b/src/components/Auth/ChangePassword/ChangePassword.react.js
@@ -86,9 +86,8 @@ export default class ChangePassword extends Component {
 
     if (event.target.name === 'password') {
       password = event.target.value;
-      let validPassword = password.length >= 6;
       state.passwordValue = password;
-      state.passwordError = !(password && validPassword);
+      state.passwordError = !password;
     } else if (event.target.name === 'newPassword') {
       newPassword = event.target.value;
       let validNewPassword = newPassword.length >= 6;
@@ -132,7 +131,7 @@ export default class ChangePassword extends Component {
     if (this.state.passwordError && event.target.name === 'password') {
       this.emailErrorMessage = '';
       this.passwordErrorMessage = (
-        <Translate text="Minimum 6 characters required" />
+        <Translate text="Password field cannot be blank" />
       );
       this.newPasswordErrorMessage = '';
       this.newPasswordConfirmErrorMessage = '';


### PR DESCRIPTION

Fixes #1730 

Changes: Password warning removed from the Current Password field. Now it only checks whether the field is blank or not.

Demo Link: https://pr-1731-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![ezgif com-video-to-gif 6](https://user-images.githubusercontent.com/31539812/48422088-e6942280-e783-11e8-97e2-18262a458911.gif)