### PR TITLE
Fixes #1758: Login loading animation stops if login fails

### DIFF
--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -101,6 +101,7 @@ class Login extends Component {
             this.setState({
               message: 'Login Failed. Try Again',
               password: '',
+              loading: false,
             });
           }
         })
@@ -108,6 +109,7 @@ class Login extends Component {
           this.setState({
             message: 'Login Failed. Try Again',
             password: '',
+            loading: false,
           });
         });
     }

--- a/src/index.js
+++ b/src/index.js
@@ -51,9 +51,15 @@ var _paq = _paq || [];
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);
 (function() {
-  var u="//matomo.anomic.de/";
-  _paq.push(['setTrackerUrl', u+'piwik.php']);
+  var u = '//matomo.anomic.de/';
+  _paq.push(['setTrackerUrl', u + 'piwik.php']);
   _paq.push(['setSiteId', '2']);
-  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-  g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  var d = document,
+    g = d.createElement('script'),
+    s = d.getElementsByTagName('script')[0];
+  g.type = 'text/javascript';
+  g.async = true;
+  g.defer = true;
+  g.src = u + 'piwik.js';
+  s.parentNode.insertBefore(g, s);
 })();


### PR DESCRIPTION
Fixes #1758 

Changes: Loading = {false} in catch block and also in then block if login fails.

Demo Link: https://pr-1756-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![ezgif-1-c87ae215e0cf](https://user-images.githubusercontent.com/19551058/48977310-ed912e00-f0bd-11e8-8ee5-a4cd779b388b.gif)

