### PR TITLE
Fix npm run build error, remove queryString #1778

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "moment": "2.22.2",
     "npm": "6.3.0",
     "prop-types": "15.6.2",
-    "query-string": "6.2.0",
     "react": "15.6.2",
     "react-bootstrap": "0.31.5",
     "react-color": "2.14.1",

--- a/src/helpers/ajax.js
+++ b/src/helpers/ajax.js
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import _ from 'lodash';
-import queryString from 'query-string';
 import { camelizeKeys, toFormData } from '../utils';
 import Cookies from 'universal-cookie';
 
@@ -43,9 +42,9 @@ const obj = {};
         };
       } else if (method === 'get') {
         if (payload) {
-          url += `?${queryString.stringify(payload, {
-            encode: false,
-          })}`;
+          url += `?${Object.keys(payload)
+            .map(key => key + '=' + payload[key])
+            .join('&')}`;
         }
       }
 


### PR DESCRIPTION
Fixes #1778 

Changes: Due to ajax.js, using queryString, the npm run build was giving an error. It is fixed now, user can build without any error.

queryString has issues with React 

Demo Link: https://pr-1778-fossasia-susi-web-chat.surge.sh

