### PR TITLE
The default languages are arranged alphabetically

### DIFF
--- a/src/constants/SettingsVoiceConstants.js
+++ b/src/constants/SettingsVoiceConstants.js
@@ -12,6 +12,14 @@ export const voiceList = [
     name: 'Deutsch',
   },
   {
+    lang: 'nl-NL',
+    name: 'Dutch',
+  },
+  {
+    lang: 'fr-FR',
+    name: 'French',
+  },
+  {
     lang: 'gr-GR',
     name: 'Greek',
   },
@@ -20,12 +28,16 @@ export const voiceList = [
     name: 'Hindi',
   },
   {
-    lang: 'pb-IN',
-    name: 'Punjabi',
+    lang: 'jp-JP',
+    name: 'Japanese',
   },
   {
     lang: 'np-NP',
     name: 'Nepali',
+  },
+  {
+    lang: 'pb-IN',
+    name: 'Punjabi',
   },
   {
     lang: 'ru-RU',
@@ -36,18 +48,6 @@ export const voiceList = [
     name: 'Spanish',
   },
   {
-    lang: 'fr-FR',
-    name: 'French',
-  },
-  {
-    lang: 'jp-JP',
-    name: 'Japanese',
-  },
-  {
-    lang: 'nl-NL',
-    name: 'Dutch',
-  },
-  {
     lang: 'en-US',
     name: 'US English',
   },
@@ -55,16 +55,24 @@ export const voiceList = [
 
 export const voiceListChange = [
   {
-    lang: 'de-DE',
-    name: 'Deutsch',
-  },
-  {
     lang: 'am-AM',
     name: 'Armenian',
   },
   {
-    lang: 'en-US',
-    name: 'US English',
+    lang: 'zh-CH',
+    name: 'Chinese',
+  },
+  {
+    lang: 'de-DE',
+    name: 'Deutsch',
+  },
+  {
+    lang: 'nl-NL',
+    name: 'Dutch',
+  },
+  {
+    lang: 'fr-FR',
+    name: 'French',
   },
   {
     lang: 'gr-GR',
@@ -75,19 +83,27 @@ export const voiceListChange = [
     name: 'Hindi',
   },
   {
-    lang: 'fr-FR',
-    name: 'French',
+    lang: 'jp-JP',
+    name: 'Japanese',
+  },
+  {
+    lang: 'np-NP',
+    name: 'Nepali',
+  },
+  {
+    lang: 'pb-IN',
+    name: 'Punjabi',
   },
   {
     lang: 'ru-RU',
     name: 'Russian',
   },
   {
-    lang: 'jp-JP',
-    name: 'Japanese',
+    lang: 'es-SP',
+    name: 'Spanish',
   },
   {
-    lang: 'nl-NL',
-    name: 'Dutch',
+    lang: 'en-US',
+    name: 'US English',
   },
 ];


### PR DESCRIPTION
Fixes #[1868](https://github.com/fossasia/chat.susi.ai/issues/1868)

Changes: The default languages are now arranged alphabetically.

Demo Link: https://pr-1872-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

Before:
![selection_042](https://user-images.githubusercontent.com/32747809/50344554-84cc9280-0551-11e9-89de-edd55e32eff3.png)

After
![selection_043](https://user-images.githubusercontent.com/32747809/50344637-d1b06900-0551-11e9-8d2a-527b9b052f5b.png)
