### PR TITLE
Fixes #1947: Workaround for captcha key loading failure

### DIFF
--- a/src/components/Auth/SignUp/SignUp.react.js
+++ b/src/components/Auth/SignUp/SignUp.react.js
@@ -283,7 +283,7 @@ class SignUp extends Component {
       !passwordErrorMessage &&
       confirmPassword &&
       !passwordConfirmErrorMessage &&
-      isCaptchaVerified;
+      (isCaptchaVerified || !captchaKey);
 
     const PasswordClass = [`is-strength-${passwordScore}`];
 


### PR DESCRIPTION
Fixes #1947 

Changes: The changes I have made are as follows:
- [x] The user can signup if the captcha key fails to load.
- [x] User won't be able to signup if the captcha keys loads and he fails to clear the robot test

Demo Link: https://pr-1957-fossasia-susi-web-chat.surge.sh