### PR TITLE
Fixes #1958: Redundant getAdmin Api calls removed from StaticAppBar and TopBar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,6 +38,7 @@ class App extends Component {
     location: PropTypes.object,
     closeVideo: PropTypes.func,
     actions: PropTypes.object,
+    accessToken: PropTypes.string,
   };
 
   constructor(props) {
@@ -56,10 +57,12 @@ class App extends Component {
   }
 
   componentDidMount = () => {
+    const { actions, accessToken } = this.props;
     window.addEventListener('offline', this.onUserOffline);
     window.addEventListener('online', this.onUserOnline);
 
-    this.props.actions.getApiKeys();
+    actions.getApiKeys();
+    accessToken && actions.getAdmin();
   };
 
   componentWillUnmount = () => {
@@ -317,9 +320,16 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
+function mapStateToProps(store) {
+  const { app } = store;
+  return {
+    ...app,
+  };
+}
+
 export default withRouter(
   connect(
-    null,
+    mapStateToProps,
     mapDispatchToProps,
   )(App),
 );

--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -116,27 +116,30 @@ class Login extends Component {
       actions
         .getLogin({ email, password: encodeURIComponent(password) })
         .then(({ payload }) => {
+          const { accessToken, time, uuid } = payload;
           let snackBarMessage;
           if (payload.accepted) {
-            // eslint-disable-next-line camelcase
-            actions.getAdmin({ access_token: payload.accessToken });
-            this.setCookies({ ...payload, email });
+            snackBarMessage = payload.message;
             actions
-              .getHistoryFromServer()
+              // eslint-disable-next-line camelcase
+              .getAdmin({ access_token: payload.accessToken })
               .then(({ payload }) => {
-                createMessagePairArray(payload).then(messagePairArray => {
-                  actions.initializeMessageStore(messagePairArray);
+                this.setCookies({ accessToken, time, uuid, email });
+                actions.getHistoryFromServer().then(({ payload }) => {
+                  // eslint-disable-next-line
+                  createMessagePairArray(payload).then(messagePairArray => {
+                    actions.initializeMessageStore(messagePairArray);
+                  });
+                });
+                this.setState({
+                  success: true,
+                  loading: false,
                 });
               })
               .catch(error => {
                 actions.initializeMessageStoreFailed();
                 console.log(error);
               });
-            this.setState({
-              success: true,
-              loading: false,
-            });
-            snackBarMessage = payload.message;
             this.handleDialogClose();
           } else {
             this.setState({
@@ -144,7 +147,7 @@ class Login extends Component {
               success: false,
               loading: false,
             });
-            snackBarMessage = 'Signup Failed. Try Again';
+            snackBarMessage = 'Login Failed. Try Again';
           }
           openSnackBar({
             snackBarMessage,

--- a/src/components/Auth/Logout.react.js
+++ b/src/components/Auth/Logout.react.js
@@ -23,7 +23,6 @@ const Logout = props => {
   deleteCookie('serverUrl', { domain: cookieDomain, path: '/' });
   deleteCookie('emailId', { domain: cookieDomain, path: '/' });
   deleteCookie('username', { domain: cookieDomain, path: '/' });
-  deleteCookie('isAdmin', { domain: cookieDomain, path: '/' });
   deleteCookie('uuid', { domain: cookieDomain, path: '/' });
 
   if (props.history) {

--- a/src/components/ChatApp/TopBar.react.js
+++ b/src/components/ChatApp/TopBar.react.js
@@ -82,9 +82,6 @@ class TopBar extends Component {
     this.setState({
       search: false,
     });
-    if (this.props.isAdmin === null && this.props.accessToken) {
-      this.props.actions.getAdmin();
-    }
   }
 
   showOptions = event => {
@@ -118,6 +115,7 @@ class TopBar extends Component {
       header,
       toggleShareClose,
       onRequestOpenLogin,
+      isAdmin,
     } = this.props;
 
     let appBarClass = 'app-bar';
@@ -245,7 +243,7 @@ class TopBar extends Component {
             />
 
             {accessToken &&
-              this.props.isAdmin && (
+              isAdmin && (
                 <MenuItem
                   primaryText={<Translate text="Admin" />}
                   rightIcon={<List />}

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -149,10 +149,6 @@ class StaticAppBar extends Component {
   };
 
   componentDidMount() {
-    const { isAdmin, accessToken, actions } = this.props;
-    if (isAdmin === null && accessToken) {
-      actions.getAdmin();
-    }
     window.addEventListener('scroll', this.handleScroll);
     let didScroll;
     let lastScrollTop = 0;


### PR DESCRIPTION
Fixes #1958 

Changes: The changes I have made are as follows:
- [x] Removed getAdmin call from TopBar
- [x] Removed getAdmin call from StaticAppBar
- [x] Rearranged the api calls in login.react.js
- [x] Save isAdmin in cookies
- [x] Use the cookie to hydrate initial app store

Demo Link: https://pr-1961-fossasia-susi-web-chat.surge.sh