### PR TITLE
Use app store to get user details instead of cookie #1976

### DIFF
--- a/src/__tests__/components/NotFound/NotFound.js
+++ b/src/__tests__/components/NotFound/NotFound.js
@@ -1,9 +1,17 @@
 import React from 'react';
 import NotFound from '../../../components/NotFound/NotFound.react';
 import { shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+const mockStore = configureMockStore();
+const store = mockStore({});
 
 describe('<NotFound />', () => {
   it('renders NotFound without crashing', () => {
-    shallow(<NotFound location={{ pathname: '' }} />);
+    shallow(
+      <Provider store={store}>
+        <NotFound location={{ pathname: '' }} />
+      </Provider>,
+    );
   });
 });

--- a/src/__tests__/components/Support/Support.js
+++ b/src/__tests__/components/Support/Support.js
@@ -1,9 +1,17 @@
 import React from 'react';
 import Support from '../../../components/Support/Support.react';
 import { shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+const mockStore = configureMockStore();
+const store = mockStore({});
 
 describe('<Support />', () => {
   it('renders Support without crashing', () => {
-    shallow(<Support location={{ pathname: '/support' }} />);
+    shallow(
+      <Provider store={store}>
+        <Support location={{ pathname: '/support' }} />
+      </Provider>,
+    );
   });
 });

--- a/src/components/Auth/ChangePassword/ChangePassword.react.js
+++ b/src/components/Auth/ChangePassword/ChangePassword.react.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import zxcvbn from 'zxcvbn';
-import Cookies from 'universal-cookie';
 import Paper from 'material-ui/Paper';
 import RaisedButton from 'material-ui/RaisedButton';
 import PasswordField from 'material-ui-password-field';
@@ -14,8 +13,6 @@ import Translate from '../../Translate/Translate.react';
 import ForgotPassword from '../ForgotPassword/ForgotPassword.react';
 import actions from '../../../redux/actions/app';
 import './ChangePassword.css';
-
-const cookies = new Cookies();
 
 const styles = {
   closingStyle: {
@@ -65,6 +62,7 @@ class ChangePassword extends Component {
     history: PropTypes.object,
     settings: PropTypes.object,
     actions: PropTypes.object,
+    email: PropTypes.string,
   };
 
   constructor(props) {
@@ -218,9 +216,7 @@ class ChangePassword extends Component {
       newPasswordErrorMessage,
       newPasswordConfirmErrorMessage,
     } = this.state;
-    const { actions } = this.props;
-
-    const email = cookies.get('emailId') ? cookies.get('emailId') : '';
+    const { actions, email } = this.props;
 
     if (
       !(
@@ -298,14 +294,21 @@ class ChangePassword extends Component {
 
     const PasswordClass = [`is-strength-${newPasswordScore}`];
 
-    const { labelStyle } = styles.labelStyle;
+    const {
+      closingStyle,
+      fieldStyle,
+      labelStyle,
+      submitBtnStyle,
+      inputStyle,
+      containerStyles,
+    } = styles;
 
     return (
       <div className="changePasswordForm">
         <Paper
           zDepth={0}
           style={{
-            ...styles.containerStyles,
+            ...containerStyles,
             backgroundColor: themeBackgroundColor,
           }}
         >
@@ -316,11 +319,11 @@ class ChangePassword extends Component {
             <div>
               <PasswordField
                 name="password"
-                style={styles.fieldStyle}
+                style={fieldStyle}
                 value={password}
                 onChange={this.handleTextFieldChange}
                 inputStyle={{
-                  ...styles.inputStyle,
+                  ...inputStyle,
                   color: themeForegroundColor,
                 }}
                 errorText={passwordErrorMessage}
@@ -338,11 +341,11 @@ class ChangePassword extends Component {
               <PasswordField
                 name="newPassword"
                 placeholder="Must be between 6 to 64 characters"
-                style={styles.fieldStyle}
+                style={fieldStyle}
                 value={newPassword}
                 onChange={this.handleTextFieldChange}
                 inputStyle={{
-                  ...styles.inputStyle,
+                  ...inputStyle,
                   color: themeForegroundColor,
                 }}
                 errorText={newPasswordErrorMessage}
@@ -362,11 +365,11 @@ class ChangePassword extends Component {
               <PasswordField
                 name="confirmNewPassword"
                 placeholder="Must match the new password"
-                style={styles.fieldStyle}
+                style={fieldStyle}
                 value={confirmNewPassword}
                 onChange={this.handleTextFieldChange}
                 inputStyle={{
-                  ...styles.inputStyle,
+                  ...inputStyle,
                   color: themeForegroundColor,
                 }}
                 errorText={newPasswordConfirmErrorMessage}
@@ -376,7 +379,7 @@ class ChangePassword extends Component {
                 visibilityIconStyle={{ display: 'none' }}
               />
             </div>
-            <div style={styles.submitBtnStyle}>
+            <div style={submitBtnStyle}>
               <div className="forgot">
                 <a onClick={this.onForgotPassword}>Forgot your password?</a>
               </div>
@@ -418,7 +421,7 @@ class ChangePassword extends Component {
             >
               <Translate text={dialogMessage} />
               <Close
-                style={styles.closingStyle}
+                style={closingStyle}
                 onTouchTap={this.handleCloseResetPassword}
               />
             </Dialog>
@@ -429,6 +432,13 @@ class ChangePassword extends Component {
   }
 }
 
+function mapStateToProps(store) {
+  const { email } = store.app;
+  return {
+    email,
+  };
+}
+
 function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(actions, dispatch),
@@ -436,6 +446,6 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(ChangePassword);

--- a/src/components/NotFound/NotFound.react.js
+++ b/src/components/NotFound/NotFound.react.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
 import RaisedButton from 'material-ui/RaisedButton';
 import Dialog from 'material-ui/Dialog';
 import ForgotPassword from '../Auth/ForgotPassword/ForgotPassword.react';
@@ -7,12 +9,8 @@ import Close from 'material-ui/svg-icons/navigation/close';
 import UserPreferencesStore from '../../stores/UserPreferencesStore';
 import Login from '../Auth/Login/Login.react';
 import SignUp from '../Auth/SignUp/SignUp.react';
-import Cookies from 'universal-cookie';
-import urls from '../../utils/urls';
 import './NotFound.css';
 import LogoImg from '../../images/susi-logo.svg';
-
-const cookies = new Cookies();
 
 const style = {
   closingStyle: {
@@ -31,7 +29,12 @@ const style = {
   },
 };
 
-export default class NotFound extends Component {
+class NotFound extends Component {
+  static propTypes = {
+    accessToken: PropTypes.string,
+    history: PropTypes.object,
+  };
+
   constructor(props) {
     super(props);
     this.state = {
@@ -54,8 +57,9 @@ export default class NotFound extends Component {
   };
   // Open Login Dialog
   handleLoginOpen = () => {
-    if (cookies.get('loggedIn')) {
-      window.location = urls.CHAT_URL;
+    const { accessToken, history } = this.props;
+    if (accessToken) {
+      history.replace('');
     } else {
       this.setState({
         loginOpen: true,
@@ -78,6 +82,7 @@ export default class NotFound extends Component {
     });
   };
   render() {
+    const { closingStyle, bodyStyle } = style;
     document.body.style.setProperty('background-image', 'none');
     return (
       <div>
@@ -128,7 +133,7 @@ export default class NotFound extends Component {
           modal={true}
           open={this.state.loginOpen}
           autoScrollBodyContent={true}
-          bodyStyle={style.bodyStyle}
+          bodyStyle={bodyStyle}
           contentStyle={{ width: '35%', minWidth: '300px' }}
           onRequestClose={this.handleClose}
         >
@@ -136,7 +141,7 @@ export default class NotFound extends Component {
             {...this.props}
             handleForgotPassword={this.handleForgotPassword}
           />
-          <Close style={style.closingStyle} onTouchTap={this.handleClose} />
+          <Close style={closingStyle} onTouchTap={this.handleClose} />
         </Dialog>
         {/* SignUp */}
         <Dialog
@@ -144,7 +149,7 @@ export default class NotFound extends Component {
           modal={true}
           open={this.state.open}
           autoScrollBodyContent={true}
-          bodyStyle={style.bodyStyle}
+          bodyStyle={bodyStyle}
           contentStyle={{ width: '35%', minWidth: '300px' }}
           onRequestClose={this.handleClose}
         >
@@ -153,7 +158,7 @@ export default class NotFound extends Component {
             onRequestClose={this.handleClose}
             onLoginSignUp={this.handleLoginOpen}
           />
-          <Close style={style.closingStyle} onTouchTap={this.handleClose} />
+          <Close style={closingStyle} onTouchTap={this.handleClose} />
         </Dialog>
         <Dialog
           className="dialogStyle"
@@ -167,9 +172,21 @@ export default class NotFound extends Component {
             {...this.props}
             showForgotPassword={this.showForgotPassword}
           />
-          <Close style={style.closingStyle} onTouchTap={this.handleClose} />
+          <Close style={closingStyle} onTouchTap={this.handleClose} />
         </Dialog>
       </div>
     );
   }
 }
+
+function mapStateToProps(store) {
+  const { accessToken } = store.app;
+  return {
+    accessToken,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null,
+)(NotFound);

--- a/src/components/Support/Support.react.js
+++ b/src/components/Support/Support.react.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Cookies from 'universal-cookie';
+import { connect } from 'react-redux';
 import RaisedButton from 'material-ui/RaisedButton';
 import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
 import Footer from '../Footer/Footer.react';
@@ -15,34 +15,19 @@ import googleGroups from '../../images/google-groups.png';
 import code from '../../images/code.png';
 import './Support.css';
 
-const cookies = new Cookies();
-
 const styles = {
   buttonStyle: {
     marginTop: '25px',
     marginBottom: '25px',
   },
-  bodyStyle: {
-    padding: 0,
-    textAlign: 'center',
-  },
-  closingStyle: {
-    position: 'absolute',
-    zIndex: 1200,
-    fill: '#444',
-    width: '26px',
-    height: '26px',
-    right: '10px',
-    top: '10px',
-    cursor: 'pointer',
-  },
 };
 
-export default class Support extends Component {
+class Support extends Component {
   static propTypes = {
     history: PropTypes.object,
     location: PropTypes.object,
     openSignUp: PropTypes.func,
+    accessToken: PropTypes.string,
   };
 
   componentDidMount() {
@@ -54,9 +39,11 @@ export default class Support extends Component {
   }
 
   render() {
+    const { buttonStyle } = styles;
+    const { location, openSignUp, accessToken } = this.props;
     return (
       <div>
-        <StaticAppBar {...this.props} location={this.props.location} />
+        <StaticAppBar {...this.props} location={location} />
         <div className="gray-wrapper">
           <div className="white-grey">
             <div className="conversation__description">
@@ -248,7 +235,7 @@ export default class Support extends Component {
           </div>
         </div>
         <div className="blue-wrapper">
-          {!cookies.get('loggedIn') ? (
+          {!accessToken ? (
             <div className="non-flex blue-background">
               <div className="conversation__description footer-desc">
                 <div className="support__heading center blue-text">
@@ -257,8 +244,8 @@ export default class Support extends Component {
 
                 <RaisedButton
                   label="Sign Up"
-                  onTouchTap={this.props.openSignUp}
-                  style={styles.buttonStyle}
+                  onTouchTap={openSignUp}
+                  style={buttonStyle}
                 />
               </div>
             </div>
@@ -270,3 +257,15 @@ export default class Support extends Component {
     );
   }
 }
+
+function mapStateToProps(store) {
+  const { accessToken } = store.app;
+  return {
+    accessToken,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null,
+)(Support);


### PR DESCRIPTION
Fixes #1976 

Changes:

- Used app store to get user details
- Connected redux with NotFound, Support
- Added Tests for NotFound, Support

Demo Link: https://pr-1977-1-fossasia-susi-web-chat.surge.sh