### PR TITLE
rectified space between the eye symbol and password textfield

### DIFF
--- a/src/components/Auth/SignUp/SignUp.react.js
+++ b/src/components/Auth/SignUp/SignUp.react.js
@@ -379,6 +379,7 @@ export default class SignUp extends Component {
       marginBottom: '10px',
       marginRight: '50px',
       width: '90%',
+      right: '4px',
     };
 
     const PasswordClass = [`is-strength-${this.state.passwordScore}`];


### PR DESCRIPTION
Fixes #1981

Changes: added space between the eye symbol and password textfield.

Demo Link: https://pr-1985-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
![signup](https://user-images.githubusercontent.com/32407962/51665595-0d58ab80-1fb4-11e9-8f82-d0804734f750.PNG)
