### PR TITLE
ProtectedRoute: prevent unwanted redirect

### DIFF
--- a/src/components/ProtectedRoute/index.js
+++ b/src/components/ProtectedRoute/index.js
@@ -1,24 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Route, Redirect } from 'react-router-dom';
+import { Route } from 'react-router-dom';
+import NotFound from '../NotFound/NotFound.react';
 
 const ProtectedRoute = props => {
-  const { accessToken, location, component: Component, ...rest } = props;
+  const { accessToken, component: Component, ...restProps } = props;
   return (
     <Route
-      {...rest}
+      {...restProps}
       render={routeProps =>
-        accessToken ? (
-          <Component {...routeProps} />
-        ) : (
-          <Redirect
-            to={{
-              pathname: '/error-404',
-              state: { from: location },
-            }}
-          />
-        )
+        accessToken ? <Component {...routeProps} /> : <NotFound />
       }
     />
   );


### PR DESCRIPTION
Fixes #1995 
Changes: Currently, in ProtectedRoute component, when the user is not logged in, it is redirecting to /error-404. Instead, it should display not found for that page.

Demo Link: https://pr-1998-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

![image](https://user-images.githubusercontent.com/31389740/51749082-6586cf00-20d4-11e9-9044-2f04fac375bd.png)

