### PR TITLE
notFound: hide login and signup buttons when logged in

### DIFF
--- a/src/components/NotFound/NotFound.react.js
+++ b/src/components/NotFound/NotFound.react.js
@@ -83,6 +83,7 @@ class NotFound extends Component {
   };
   render() {
     const { closingStyle, bodyStyle } = style;
+    const { accessToken } = this.props;
     document.body.style.setProperty('background-image', 'none');
     return (
       <div>
@@ -106,25 +107,29 @@ class NotFound extends Component {
               />
             </Link>
             <br />
-            <RaisedButton
-              className="notfound-button"
-              label="SignUp to SUSI"
-              onTouchTap={this.handleOpen}
-              backgroundColor={
-                UserPreferencesStore.getTheme() ? '#4285f4' : '#19314B'
-              }
-              labelColor="#fff"
-            />
-            <br />
-            <RaisedButton
-              className="notfound-button"
-              label="Login to SUSI"
-              onTouchTap={this.handleLoginOpen}
-              backgroundColor={
-                UserPreferencesStore.getTheme() ? '#4285f4' : '#19314B'
-              }
-              labelColor="#fff"
-            />
+            {!accessToken && (
+              <div>
+                <RaisedButton
+                  className="notfound-button"
+                  label="SignUp to SUSI"
+                  onTouchTap={this.handleOpen}
+                  backgroundColor={
+                    UserPreferencesStore.getTheme() ? '#4285f4' : '#19314B'
+                  }
+                  labelColor="#fff"
+                />
+                <br />
+                <RaisedButton
+                  className="notfound-button"
+                  label="Login to SUSI"
+                  onTouchTap={this.handleLoginOpen}
+                  backgroundColor={
+                    UserPreferencesStore.getTheme() ? '#4285f4' : '#19314B'
+                  }
+                  labelColor="#fff"
+                />
+              </div>
+            )}
           </div>
         </div>
         {/* Login */}


### PR DESCRIPTION
Fixes #1997 

Changes: When user is logged in, login and signup buttons should not be visible on 404 page

Demo Link: https://pr-2000-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 

![image](https://user-images.githubusercontent.com/31389740/51764609-9cbca680-20fb-11e9-91d1-ed17fe743d1a.png)

