### PR TITLE
fix: top right menu button not aligned properly

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.css
+++ b/src/components/StaticAppBar/StaticAppBar.css
@@ -61,7 +61,7 @@ a.drawerItem {
     display: flex;
     justify-content: center;
     align-items: center;
-    margin-right: -8px;
+    margin-right: 8px;
     margin-top: 1px;
 }
 @media(max-width: 1000px){


### PR DESCRIPTION
fixed #2001 top right menu button not aligned properly in about section of app

changed the margin-right from -8px to 8px

fix: #2001 