### PR TITLE
Omitted Google+ from 'Settings'->'Share on Social Media'.  Fixes #2032 

### DIFF
--- a/src/components/ChatApp/Settings/ShareOnSocialMedia.js
+++ b/src/components/ChatApp/Settings/ShareOnSocialMedia.js
@@ -95,24 +95,6 @@ const ShareOnSocialMedia = props => {
               }
             />
           </div>
-          <div style={props.headingStyle}>
-            <Translate text="Share about SUSI on Google+" />
-            <br />
-            <RaisedButton
-              label={<Translate text="Share on Google+" />}
-              style={raisedButtonStyle}
-              backgroundColor="#d34836"
-              labelColor="#fff"
-              icon={<FontIcon className="fa fa-google-plus" />}
-              keyboardFocused={false}
-              onClick={() =>
-                window.open(
-                  `https://plus.google.com/share?url=${urls.CHAT_URL}`,
-                  '_blank',
-                )
-              }
-            />
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #2032

Changes: Removed Google+ share option from Settings->Share on Social Media.
Reason being no Google+ share option on Share tab from header scroll down list. Erasing Google+ is a better solution since it is going to end its feature due 2nd April 2019.
Commented the undesired part.

Screenshots for the change: 
After changes:-

![without_google](https://user-images.githubusercontent.com/34474021/52417352-b6091e00-2b11-11e9-9ee8-b8c5f6c9eae7.png)

Before Modification:-

![share_tab](https://user-images.githubusercontent.com/34474021/52417406-d46f1980-2b11-11e9-8fb1-0c75fe32078b.png)
![share_on_social_media](https://user-images.githubusercontent.com/34474021/52417411-d46f1980-2b11-11e9-9e3c-0d1f4e959572.png)

Objective:- Equalizing Share tab in scroll down list and 'Share on Social Media' tab in settings from scroll down list. 

