### PR TITLE
position of top right menu button corrected

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.css
+++ b/src/components/StaticAppBar/StaticAppBar.css
@@ -61,7 +61,6 @@ a.drawerItem {
     display: flex;
     justify-content: center;
     align-items: center;
-    margin-right: -8px;
     margin-top: 1px;
 }
 @media(max-width: 1000px){


### PR DESCRIPTION
Fixes #2041 

Changes: Removed a right-margin of -8px from TopRightMenu.

Screenshots for the change: 
![corrected1](https://user-images.githubusercontent.com/35253743/52610282-89a12900-2ea6-11e9-9808-2320abc18afe.png)