### PR TITLE
Add scroll ToTopButton to Team page

### DIFF
--- a/src/components/Blog/Blog.react.js
+++ b/src/components/Blog/Blog.react.js
@@ -23,6 +23,7 @@ import 'font-awesome/css/font-awesome.min.css';
 import Next from 'material-ui/svg-icons/hardware/keyboard-arrow-right';
 import Previous from 'material-ui/svg-icons/hardware/keyboard-arrow-left';
 import susi from '../../images/susi-logo.svg';
+import ToTopButton from '../Button/ToTopButton.react';
 const { FacebookShareButton, TwitterShareButton } = ShareButtons;
 const FacebookIcon = generateShareIcon('facebook');
 const TwitterIcon = generateShareIcon('twitter');
@@ -176,12 +177,6 @@ class Blog extends Component {
 
     const prevStyle = {
       visibility: this.state.prevDisplay,
-    };
-    const toTopStyle = {
-      right: 80,
-      bottom: 80,
-      position: 'fixed',
-      zIndex: '10',
     };
 
     return (
@@ -368,15 +363,7 @@ class Blog extends Component {
             <Footer />
           </div>
         )}
-        <FloatingActionButton
-          style={toTopStyle}
-          backgroundColor={'#4285f4'}
-          onClick={() => {
-            scrollToTopAnimation();
-          }}
-        >
-          <span className="fa fa-chevron-up" />
-        </FloatingActionButton>
+        <ToTopButton />
       </div>
     );
   }

--- a/src/components/Button/ToTopButton.react.js
+++ b/src/components/Button/ToTopButton.react.js
@@ -1,0 +1,26 @@
+import FloatingActionButton from 'material-ui/FloatingActionButton';
+import { scrollToTopAnimation } from '../../utils/animateScroll';
+import React from 'react';
+
+const toTopStyle = {
+  right: 80,
+  bottom: 80,
+  position: 'fixed',
+  zIndex: '11',
+};
+
+const ToTopButton = () => {
+  return (
+    <FloatingActionButton
+      style={toTopStyle}
+      backgroundColor={'#4285f4'}
+      onClick={() => {
+        scrollToTopAnimation();
+      }}
+    >
+      <span className="fa fa-chevron-up" />
+    </FloatingActionButton>
+  );
+};
+
+export default ToTopButton;

--- a/src/components/Team/Team.react.js
+++ b/src/components/Team/Team.react.js
@@ -8,6 +8,7 @@ import { scrollToTopAnimation } from '../../utils/animateScroll';
 import TEAM_MEMBERS from './constants';
 import 'font-awesome/css/font-awesome.min.css';
 import './Team.css';
+import ToTopButton from '../Button/ToTopButton.react';
 
 export default class Team extends Component {
   static propTypes = {
@@ -100,6 +101,7 @@ export default class Team extends Component {
           <div className="team-container">{alumnis}</div>
         </div>
 
+        <ToTopButton />
         <Footer />
       </div>
     );


### PR DESCRIPTION
Fixes #2067 

Changes: I initially just wanted to add a scroll To Top button on the 'Team' page, but since we already had such a button, and I figured it could be reused on multiple pages, I abstracted it out in `ToTopButton.react.js`, and inserted it back into the 'Blog' and 'Team' pages. 

Demo Link: https://pr-2068-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 

<img width="1440" alt="Screenshot 2019-03-21 at 3 22 24 PM" src="https://user-images.githubusercontent.com/28834838/54737977-3df04680-4bed-11e9-8adb-ddd242bd9266.png">
