### PR TITLE
Make getUserSettings to be called on root component and fix loading of Settings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,7 @@ import SignUp from './components/Auth/SignUp/SignUp.react';
 import ForgotPassword from './components/Auth/ForgotPassword/ForgotPassword.react';
 import actions from './redux/actions/app';
 import ProtectedRoute from './components/ProtectedRoute';
+import { getSettings } from './utils/ChatWebAPIUtils';
 
 const muiTheme = getMuiTheme({
   toggle: {
@@ -63,6 +64,7 @@ class App extends Component {
 
     actions.getApiKeys();
     accessToken && actions.getAdmin();
+    accessToken && getSettings();
   };
 
   componentWillUnmount = () => {

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -214,7 +214,14 @@ class StaticAppBar extends Component {
       popOverStyle,
       linkLabelStyle,
     } = styles;
-    const { accessToken, settings, location, email, userName } = this.props;
+    const {
+      accessToken,
+      settings,
+      location,
+      email,
+      userName,
+      isAdmin,
+    } = this.props;
     const { isPopUpMenuOpen, anchorEl, isDrawerOpen } = this.state;
     // Check the path to show or not to show top bar left menu
     let showLeftMenu = 'block';
@@ -257,7 +264,7 @@ class StaticAppBar extends Component {
           containerElement={<Link to="/overview" />}
           rightIcon={<Info />}
         />
-        {this.state.showAdmin === true ? (
+        {isAdmin === true ? (
           <MenuItem
             primaryText={<Translate text="Admin" />}
             rightIcon={<List />}


### PR DESCRIPTION
Fixes #2084 

Changes: Remove the code which was causing the settings to be not functional.
Redux is already integrated in Static App bar. 
Actions.getSettings() functions in index.js calls the getUserSettings function which lists the user settings.
Demo Link: https://pr-2085-fossasia-susi-web-chat.surge.sh
